### PR TITLE
Adding support for recording instances from heartbeats

### DIFF
--- a/lib/lattice_observer/nats_observer.ex
+++ b/lib/lattice_observer/nats_observer.ex
@@ -62,15 +62,13 @@ defmodule LatticeObserver.NatsObserver do
         Logger.debug("Processing event #{evt.type}")
         nstate = %{state | lc: LatticeObserver.Observed.Lattice.apply_event(state.lc, evt)}
 
-        if nstate != state do
-          LatticeObserver.Observer.execute(
-            state.module,
-            state.lc,
-            nstate.lc,
-            evt,
-            state.lattice_prefix
-          )
-        end
+        LatticeObserver.Observer.execute(
+          state.module,
+          state.lc,
+          nstate.lc,
+          evt,
+          state.lattice_prefix
+        )
 
         {:noreply, nstate}
 
@@ -89,15 +87,13 @@ defmodule LatticeObserver.NatsObserver do
       | lc: state.lc |> LatticeObserver.Observed.Lattice.apply_event(tick)
     }
 
-    if nstate != state do
-      LatticeObserver.Observer.execute(
-        state.module,
-        state.lc,
-        nstate.lc,
-        tick,
-        state.lattice_prefix
-      )
-    end
+    LatticeObserver.Observer.execute(
+      state.module,
+      state.lc,
+      nstate.lc,
+      tick,
+      state.lattice_prefix
+    )
 
     {:noreply, nstate}
   end

--- a/test/observed/hosts_test.exs
+++ b/test/observed/hosts_test.exs
@@ -86,6 +86,92 @@ defmodule LatticeObserverTest.Observed.HostsTest do
       assert l.hosts[@test_host].labels == %{baz: "biz", foo: "bar"}
       assert l.hosts[@test_host].status == :healthy
       assert l.hosts[@test_host].last_seen == stamp2
+
+      hb3 =
+        CloudEvents.host_heartbeat(
+          @test_host,
+          %{foo: "bar"},
+          [
+            %{
+              "public_key" => "Mxxxx",
+              "instance_id" => "iid1"
+            },
+            %{
+              "public_key" => "Mxxxy",
+              "instance_id" => "iid2"
+            }
+          ],
+          [
+            %{
+              "public_key" => "Vxxxxx",
+              "instance_id" => "iid3",
+              "contract_id" => "wasmcloud:test",
+              "link_name" => "default"
+            }
+          ]
+        )
+
+      l = Lattice.apply_event(Lattice.new(), hb3)
+
+      assert l.actors == %{
+               "Mxxxx" => %LatticeObserver.Observed.Actor{
+                 call_alias: "",
+                 capabilities: [],
+                 id: "Mxxxx",
+                 instances: [
+                   %LatticeObserver.Observed.Instance{
+                     host_id: "Nxxx",
+                     id: "iid1",
+                     revision: 0,
+                     spec_id: "",
+                     version: ""
+                   }
+                 ],
+                 issuer: "",
+                 name: "unavailable",
+                 tags: [],
+                 version: nil
+               },
+               "Mxxxy" => %LatticeObserver.Observed.Actor{
+                 call_alias: "",
+                 capabilities: [],
+                 id: "Mxxxy",
+                 instances: [
+                   %LatticeObserver.Observed.Instance{
+                     host_id: "Nxxx",
+                     id: "iid2",
+                     revision: 0,
+                     spec_id: "",
+                     version: ""
+                   }
+                 ],
+                 issuer: "",
+                 name: "unavailable",
+                 tags: [],
+                 version: nil
+               }
+             }
+
+      assert l.providers == %{
+               {"Vxxxxx", "default"} => %LatticeObserver.Observed.Provider{
+                 contract_id: "wasmcloud:test",
+                 id: "Vxxxxx",
+                 instances: [
+                   %LatticeObserver.Observed.Instance{
+                     host_id: "Nxxx",
+                     id: "iid3",
+                     revision: 0,
+                     spec_id: "",
+                     version: ""
+                   }
+                 ],
+                 issuer: "",
+                 link_name: "default",
+                 name: "unavailable",
+                 tags: [],
+                 version: nil
+               }
+             }
     end
   end
 end

--- a/test/support/cloud_events.ex
+++ b/test/support/cloud_events.ex
@@ -102,10 +102,10 @@ defmodule TestSupport.CloudEvents do
     |> LatticeObserver.CloudEvent.new("provider_stopped", host)
   end
 
-  def host_heartbeat(host, labels) do
+  def host_heartbeat(host, labels, actors \\ [], providers \\ []) do
     %{
-      "actors" => [],
-      "providers" => [],
+      "actors" => actors,
+      "providers" => providers,
       "labels" => labels
     }
     |> LatticeObserver.CloudEvent.new("host_heartbeat", host)


### PR DESCRIPTION
This PR also removes the guard clause that doesn't forward events when state remains unmodified. It will now be the responsibility of downstream consumers to perform whatever diff they like and react accordingly. We don't want the lattice observer to make assumptions about how the consumers will use the data/events.