### PR TITLE
Added provider_start_failed to the events handled

### DIFF
--- a/lib/lattice_observer/observed/lattice.ex
+++ b/lib/lattice_observer/observed/lattice.ex
@@ -184,6 +184,19 @@ defmodule LatticeObserver.Observed.Lattice do
   def apply_event(
         l = %Lattice{},
         %Cloudevents.Format.V_1_0.Event{
+          source: _source_host,
+          datacontenttype: "application/json",
+          time: _stamp,
+          type: "com.wasmcloud.lattice.provider_start_failed"
+        }
+      ) do
+    # This does not currently affect state, but shouldn't generate a warning either
+    l
+  end
+
+  def apply_event(
+        l = %Lattice{},
+        %Cloudevents.Format.V_1_0.Event{
           data:
             %{
               "link_name" => link_name,


### PR DESCRIPTION
Similar to adding `actor_start_failed` in #5, `provider_start_failed` is another event that a consumer should be able to observe as it indicates that an operation failed and can be handled accordingly.