### PR TITLE
Support for monitoring invocation success/fail

### DIFF
--- a/lib/lattice_observer/observed/event_processor.ex
+++ b/lib/lattice_observer/observed/event_processor.ex
@@ -1,0 +1,257 @@
+defmodule LatticeObserver.Observed.EventProcessor do
+  alias LatticeObserver.Observed.{Lattice, Provider, Host, Actor, Instance, LinkDefinition, Decay}
+
+  def put_actor_instance(l = %Lattice{}, host_id, pk, instance_id, spec, stamp, claims)
+      when is_binary(pk) and is_binary(instance_id) and is_binary(spec) do
+    actor =
+      Map.get(l.actors, pk, %Actor{
+        id: pk,
+        name: Map.get(claims, "name", "unavailable"),
+        capabilities: Map.get(claims, "caps", []),
+        issuer: Map.get(claims, "issuer", ""),
+        tags: Map.get(claims, "tags", []),
+        call_alias: Map.get(claims, "call_alias", ""),
+        instances: []
+      })
+
+    instance = %Instance{
+      id: instance_id,
+      host_id: host_id,
+      spec_id: spec,
+      version: Map.get(claims, "version", ""),
+      revision: Map.get(claims, "revision", 0)
+    }
+
+    actor =
+      if actor.instances |> Enum.find(fn i -> i.id == instance_id end) == nil do
+        %{actor | instances: [instance | actor.instances]}
+      else
+        actor
+      end
+
+    %Lattice{
+      l
+      | actors: Map.put(l.actors, pk, actor),
+        instance_tracking:
+          Map.put(l.instance_tracking, instance.id, timestamp_from_iso8601(stamp))
+    }
+  end
+
+  def put_provider_instance(
+        l = %Lattice{},
+        source_host,
+        pk,
+        link_name,
+        contract_id,
+        instance_id,
+        spec,
+        stamp,
+        claims
+      ) do
+    provider =
+      Map.get(l.providers, {pk, link_name}, %Provider{
+        id: pk,
+        name: Map.get(claims, "name", "unavailable"),
+        issuer: Map.get(claims, "issuer", ""),
+        contract_id: contract_id,
+        tags: Map.get(claims, "tags", []),
+        link_name: link_name,
+        instances: []
+      })
+
+    instance = %Instance{
+      id: instance_id,
+      host_id: source_host,
+      spec_id: spec,
+      version: Map.get(claims, "version", ""),
+      revision: Map.get(claims, "revision", 0)
+    }
+
+    provider =
+      if provider.instances |> Enum.find(fn i -> i.id == instance_id end) == nil do
+        %{provider | instances: [instance | provider.instances]}
+      else
+        provider
+      end
+
+    %Lattice{
+      l
+      | providers: Map.put(l.providers, {pk, link_name}, provider),
+        instance_tracking:
+          Map.put(l.instance_tracking, instance.id, timestamp_from_iso8601(stamp))
+    }
+  end
+
+  def remove_provider_instance(l, _source_host, pk, link_name, instance_id, _spec) do
+    provider = l.providers[{pk, link_name}]
+
+    if provider != nil do
+      provider = %Provider{
+        provider
+        | instances: provider.instances |> Enum.reject(fn i -> i.id == instance_id end)
+      }
+
+      %Lattice{
+        l
+        | providers: Map.put(l.providers, {pk, link_name}, provider),
+          instance_tracking: l.instance_tracking |> Map.delete(instance_id)
+      }
+      |> strip_instanceless_entities()
+    else
+      l
+    end
+  end
+
+  def remove_host(l = %Lattice{}, source_host) do
+    # NOTE: the instance_tracking map will purge unseen instances
+    # during the decay event processing.
+
+    l = %Lattice{
+      l
+      | hosts: Map.delete(l.hosts, source_host),
+        actors:
+          l.actors
+          |> Enum.map(fn {k, v} ->
+            {k,
+             %Actor{
+               v
+               | instances: v.instances |> Enum.reject(fn i -> i.host_id == source_host end)
+             }}
+          end)
+          |> Enum.into(%{}),
+        providers:
+          l.providers
+          |> Enum.map(fn {k, v} ->
+            {k,
+             %Provider{
+               v
+               | instances: v.instances |> Enum.reject(fn i -> i.host_id == source_host end)
+             }}
+          end)
+          |> Enum.into(%{})
+    }
+
+    l |> strip_instanceless_entities()
+  end
+
+  def strip_instanceless_entities(l = %Lattice{}) do
+    %Lattice{
+      l
+      | actors: l.actors |> Enum.reject(fn {_k, v} -> v.instances == [] end) |> Enum.into(%{}),
+        providers:
+          l.providers |> Enum.reject(fn {_k, v} -> v.instances == [] end) |> Enum.into(%{})
+    }
+  end
+
+  def record_heartbeat(l = %Lattice{}, source_host, stamp, data) do
+    labels = Map.get(data, "labels", %{})
+    l = record_host(l, source_host, labels, stamp)
+
+    l =
+      List.foldl(Map.get(data, "actors", []), l, fn x, acc ->
+        # TODO - once the host can emit annotations we can pull the spec
+        put_actor_instance(acc, source_host, x["public_key"], x["instance_id"], "", stamp, %{})
+      end)
+
+    l =
+      List.foldl(Map.get(data, "providers", []), l, fn x, acc ->
+        # TODO - once the host emits annotations we can pull the spec
+        put_provider_instance(
+          acc,
+          source_host,
+          x["public_key"],
+          x["link_name"],
+          x["contract_id"],
+          x["instance_id"],
+          "",
+          stamp,
+          %{}
+        )
+      end)
+
+    l
+  end
+
+  def record_host(l = %Lattice{}, source_host, labels, stamp) do
+    host =
+      Map.get(l.hosts, source_host, %Host{
+        id: source_host,
+        labels: labels,
+        first_seen: timestamp_from_iso8601(stamp)
+      })
+
+    # Every time we see a host, we set the last seen stamp
+    # and bump it to healthy (TODO: support aggregate status based on
+    # host contents)
+    host =
+      Map.merge(
+        host,
+        %{
+          last_seen: timestamp_from_iso8601(stamp),
+          status: :healthy
+        }
+      )
+
+    %Lattice{l | hosts: Map.put(l.hosts, source_host, host)}
+  end
+
+  def put_linkdef(l = %Lattice{}, actor_id, link_name, provider_id, contract_id, values) do
+    case Enum.find(l.linkdefs, fn link ->
+           link.actor_id == actor_id && link.provider_id == provider_id &&
+             link.link_name == link_name
+         end) do
+      nil ->
+        ld = %LinkDefinition{
+          actor_id: actor_id,
+          link_name: link_name,
+          provider_id: provider_id,
+          contract_id: contract_id,
+          values: values
+        }
+
+        %Lattice{l | linkdefs: [ld | l.linkdefs]}
+
+      _ ->
+        l
+    end
+  end
+
+  def del_linkdef(l = %Lattice{}, actor_id, link_name, provider_id) do
+    %Lattice{
+      l
+      | linkdefs:
+          Enum.reject(l.linkdefs, fn link ->
+            link.actor_id == actor_id && link.link_name == link_name &&
+              link.provider_id == provider_id
+          end)
+    }
+  end
+
+  def remove_actor_instance(l = %Lattice{}, _host_id, pk, instance_id, _spec) do
+    actor = l.actors[pk]
+
+    if actor != nil do
+      actor = %Actor{
+        actor
+        | instances: actor.instances |> Enum.reject(fn i -> i.id == instance_id end)
+      }
+
+      %Lattice{
+        l
+        | actors: Map.put(l.actors, pk, actor),
+          instance_tracking: l.instance_tracking |> Map.delete(instance_id)
+      }
+      |> strip_instanceless_entities()
+    else
+      l
+    end
+  end
+
+  @spec timestamp_from_iso8601(binary) :: DateTime.t()
+  def timestamp_from_iso8601(stamp) when is_binary(stamp) do
+    case DateTime.from_iso8601(stamp) do
+      {:ok, datetime, 0} -> datetime
+      _ -> DateTime.utc_now()
+    end
+  end
+end

--- a/lib/lattice_observer/observed/event_processor.ex
+++ b/lib/lattice_observer/observed/event_processor.ex
@@ -1,5 +1,5 @@
 defmodule LatticeObserver.Observed.EventProcessor do
-  alias LatticeObserver.Observed.{Lattice, Provider, Host, Actor, Instance, LinkDefinition, Decay}
+  alias LatticeObserver.Observed.{Lattice, Provider, Host, Actor, Instance, LinkDefinition}
 
   def put_actor_instance(l = %Lattice{}, host_id, pk, instance_id, spec, stamp, claims)
       when is_binary(pk) and is_binary(instance_id) and is_binary(spec) do

--- a/lib/lattice_observer/observed/invocation.ex
+++ b/lib/lattice_observer/observed/invocation.ex
@@ -1,0 +1,106 @@
+defmodule LatticeObserver.Observed.Invocation do
+  alias LatticeObserver.Observed.Lattice
+  alias __MODULE__.Entity
+
+  @type invocationlog_key :: {from :: Entity.t(), to :: Entity.t(), operation :: String.t()}
+  @type invocationlog_map :: %{required(invocationlog_key()) => InvocationLog.t()}
+
+  defmodule InvocationLog do
+    @type t :: %InvocationLog{
+            from: Entity.t(),
+            to: Entity.t(),
+            operation: String.t(),
+            total_bytes: Integer.t(),
+            fail_count: Integer.t(),
+            success_count: Integer.t()
+          }
+
+    defstruct [:from, :to, :operation, :total_bytes, :fail_count, :success_count]
+
+    def from_key({from, to, operation}) do
+      %InvocationLog{
+        from: from,
+        to: to,
+        operation: operation,
+        total_bytes: 0,
+        fail_count: 0,
+        success_count: 0
+      }
+    end
+  end
+
+  defmodule Entity do
+    @type t :: %Entity{
+            public_key: String.t(),
+            link_name: String.t() | nil,
+            contract_id: String.t() | nil
+          }
+    defstruct [:public_key, :link_name, :contract_id]
+
+    def from_event_entity(entity) do
+      %Entity{
+        public_key: Map.get(entity, "public_key"),
+        link_name: Map.get(entity, "link_name") |> nillify_empty(),
+        contract_id: Map.get(entity, "contract_id") |> nillify_empty()
+      }
+    end
+
+    defp nillify_empty(nil), do: nil
+
+    defp nillify_empty(str) do
+      if String.trim(str) == "" do
+        nil
+      else
+        str
+      end
+    end
+  end
+
+  @spec record_invocation_success(
+          Lattice.t(),
+          source :: Map.t(),
+          dest :: Map.t(),
+          operation :: String.t(),
+          Integer.t()
+        ) ::
+          Lattice.t()
+  def record_invocation_success(l = %Lattice{}, source, dest, operation, bytes) do
+    key = {source |> Entity.from_event_entity(), dest |> Entity.from_event_entity(), operation}
+    old_log = Map.get(l.invocation_log, key, key |> InvocationLog.from_key())
+
+    log = %InvocationLog{
+      old_log
+      | total_bytes: old_log.total_bytes + bytes,
+        success_count: old_log.success_count + 1
+    }
+
+    %Lattice{
+      l
+      | invocation_log: Map.put(l.invocation_log, key, log)
+    }
+  end
+
+  @spec record_invocation_failed(
+          Lattice.t(),
+          source :: Map.t(),
+          dest :: Map.t(),
+          operation :: String.t(),
+          Integer.t()
+        ) ::
+          Lattice.t()
+  def record_invocation_failed(l = %Lattice{}, source, dest, operation, bytes) do
+    key = {source |> Entity.from_event_entity(), dest |> Entity.from_event_entity(), operation}
+    old_log = Map.get(l.invocation_log, key, key |> InvocationLog.from_key())
+
+    log = %InvocationLog{
+      old_log
+      | total_bytes: old_log.total_bytes + bytes,
+        fail_count: old_log.fail_count + 1
+    }
+
+    %Lattice{
+      l
+      | invocation_log: Map.put(l.invocation_log, key, log)
+    }
+  end
+end

--- a/lib/lattice_observer/observed/lattice.ex
+++ b/lib/lattice_observer/observed/lattice.ex
@@ -7,7 +7,16 @@ defmodule LatticeObserver.Observed.Lattice do
   lattice events
   """
   alias __MODULE__
-  alias LatticeObserver.Observed.{Provider, Host, Actor, Instance, LinkDefinition, Decay}
+
+  alias LatticeObserver.Observed.{
+    Provider,
+    Host,
+    Actor,
+    Instance,
+    LinkDefinition,
+    Decay,
+    EventProcessor
+  }
 
   require Logger
 
@@ -54,7 +63,7 @@ defmodule LatticeObserver.Observed.Lattice do
           parameters: [Parameters.t()]
         }
 
-  @spec new(keyword) :: t()
+  @spec new(Keyword.t()) :: LatticeObserver.Observed.Lattice.t()
   def new(parameters \\ []) do
     %Lattice{
       actors: %{},
@@ -90,7 +99,7 @@ defmodule LatticeObserver.Observed.Lattice do
           type: "com.wasmcloud.lattice.host_heartbeat"
         }
       ) do
-    record_heartbeat(l, source_host, stamp, data)
+    EventProcessor.record_heartbeat(l, source_host, stamp, data)
   end
 
   def apply_event(
@@ -104,7 +113,7 @@ defmodule LatticeObserver.Observed.Lattice do
         }
       ) do
     labels = Map.get(data, "labels", %{})
-    record_host(l, source_host, labels, stamp)
+    EventProcessor.record_host(l, source_host, labels, stamp)
   end
 
   def apply_event(
@@ -115,7 +124,7 @@ defmodule LatticeObserver.Observed.Lattice do
           type: "com.wasmcloud.lattice.host_stopped"
         }
       ) do
-    remove_host(l, source_host)
+    EventProcessor.remove_host(l, source_host)
   end
 
   def apply_event(
@@ -168,7 +177,7 @@ defmodule LatticeObserver.Observed.Lattice do
     spec = Map.get(annotations, @annotation_app_spec, "")
     claims = Map.get(d, "claims", %{})
 
-    put_provider_instance(
+    EventProcessor.put_provider_instance(
       l,
       source_host,
       pk,
@@ -211,7 +220,7 @@ defmodule LatticeObserver.Observed.Lattice do
       ) do
     annotations = Map.get(d, "annotations", %{})
     spec = Map.get(annotations, @annotation_app_spec, "")
-    remove_provider_instance(l, source_host, pk, link_name, instance_id, spec)
+    EventProcessor.remove_provider_instance(l, source_host, pk, link_name, instance_id, spec)
   end
 
   def apply_event(
@@ -228,7 +237,7 @@ defmodule LatticeObserver.Observed.Lattice do
         }
       ) do
     spec = Map.get(d, "annotations", %{}) |> Map.get(@annotation_app_spec, "")
-    remove_actor_instance(l, source_host, pk, instance_id, spec)
+    EventProcessor.remove_actor_instance(l, source_host, pk, instance_id, spec)
   end
 
   def apply_event(
@@ -247,7 +256,7 @@ defmodule LatticeObserver.Observed.Lattice do
       ) do
     spec = Map.get(d, "annotations", %{}) |> Map.get(@annotation_app_spec, "")
     claims = Map.get(d, "claims", %{})
-    put_actor_instance(l, source_host, pk, instance_id, spec, stamp, claims)
+    EventProcessor.put_actor_instance(l, source_host, pk, instance_id, spec, stamp, claims)
   end
 
   def apply_event(
@@ -278,7 +287,7 @@ defmodule LatticeObserver.Observed.Lattice do
           type: "com.wasmcloud.lattice.linkdef_set"
         }
       ) do
-    put_linkdef(l, actor_id, link_name, provider_id, contract_id, values)
+    EventProcessor.put_linkdef(l, actor_id, link_name, provider_id, contract_id, values)
   end
 
   def apply_event(
@@ -295,7 +304,7 @@ defmodule LatticeObserver.Observed.Lattice do
           type: "com.wasmcloud.lattice.linkdef_deleted"
         }
       ) do
-    del_linkdef(l, actor_id, link_name, provider_id)
+    EventProcessor.del_linkdef(l, actor_id, link_name, provider_id)
   end
 
   def apply_event(l = %Lattice{}, %Cloudevents.Format.V_1_0.Event{
@@ -327,267 +336,13 @@ defmodule LatticeObserver.Observed.Lattice do
         type: "com.wasmcloud.synthetic.decay_ticked",
         time: stamp
       }) do
-    event_time = timestamp_from_iso8601(stamp)
+    event_time = EventProcessor.timestamp_from_iso8601(stamp)
     Decay.age_hosts(l, event_time)
   end
 
   def apply_event(l = %Lattice{}, evt) do
     Logger.warn("Unexpected event: #{inspect(evt)}")
     l
-  end
-
-  defp put_linkdef(l = %Lattice{}, actor_id, link_name, provider_id, contract_id, values) do
-    case Enum.find(l.linkdefs, fn link ->
-           link.actor_id == actor_id && link.provider_id == provider_id &&
-             link.link_name == link_name
-         end) do
-      nil ->
-        ld = %LinkDefinition{
-          actor_id: actor_id,
-          link_name: link_name,
-          provider_id: provider_id,
-          contract_id: contract_id,
-          values: values
-        }
-
-        %Lattice{l | linkdefs: [ld | l.linkdefs]}
-
-      _ ->
-        l
-    end
-  end
-
-  defp del_linkdef(l = %Lattice{}, actor_id, link_name, provider_id) do
-    %Lattice{
-      l
-      | linkdefs:
-          Enum.reject(l.linkdefs, fn link ->
-            link.actor_id == actor_id && link.link_name == link_name &&
-              link.provider_id == provider_id
-          end)
-    }
-  end
-
-  defp remove_actor_instance(l = %Lattice{}, _host_id, pk, instance_id, _spec) do
-    actor = l.actors[pk]
-
-    if actor != nil do
-      actor = %Actor{
-        actor
-        | instances: actor.instances |> Enum.reject(fn i -> i.id == instance_id end)
-      }
-
-      %Lattice{
-        l
-        | actors: Map.put(l.actors, pk, actor),
-          instance_tracking: l.instance_tracking |> Map.delete(instance_id)
-      }
-      |> strip_instanceless_entities()
-    else
-      l
-    end
-  end
-
-  defp put_actor_instance(l = %Lattice{}, host_id, pk, instance_id, spec, stamp, claims)
-       when is_binary(pk) and is_binary(instance_id) and is_binary(spec) do
-    actor =
-      Map.get(l.actors, pk, %Actor{
-        id: pk,
-        name: Map.get(claims, "name", "unavailable"),
-        capabilities: Map.get(claims, "caps", []),
-        issuer: Map.get(claims, "issuer", ""),
-        tags: Map.get(claims, "tags", []),
-        call_alias: Map.get(claims, "call_alias", ""),
-        instances: []
-      })
-
-    instance = %Instance{
-      id: instance_id,
-      host_id: host_id,
-      spec_id: spec,
-      version: Map.get(claims, "version", ""),
-      revision: Map.get(claims, "revision", 0)
-    }
-
-    actor =
-      if actor.instances |> Enum.find(fn i -> i.id == instance_id end) == nil do
-        %{actor | instances: [instance | actor.instances]}
-      else
-        actor
-      end
-
-    %Lattice{
-      l
-      | actors: Map.put(l.actors, pk, actor),
-        instance_tracking:
-          Map.put(l.instance_tracking, instance.id, timestamp_from_iso8601(stamp))
-    }
-  end
-
-  defp put_provider_instance(
-         l = %Lattice{},
-         source_host,
-         pk,
-         link_name,
-         contract_id,
-         instance_id,
-         spec,
-         stamp,
-         claims
-       ) do
-    provider =
-      Map.get(l.providers, {pk, link_name}, %Provider{
-        id: pk,
-        name: Map.get(claims, "name", "unavailable"),
-        issuer: Map.get(claims, "issuer", ""),
-        contract_id: contract_id,
-        tags: Map.get(claims, "tags", []),
-        link_name: link_name,
-        instances: []
-      })
-
-    instance = %Instance{
-      id: instance_id,
-      host_id: source_host,
-      spec_id: spec,
-      version: Map.get(claims, "version", ""),
-      revision: Map.get(claims, "revision", 0)
-    }
-
-    provider =
-      if provider.instances |> Enum.find(fn i -> i.id == instance_id end) == nil do
-        %{provider | instances: [instance | provider.instances]}
-      else
-        provider
-      end
-
-    %Lattice{
-      l
-      | providers: Map.put(l.providers, {pk, link_name}, provider),
-        instance_tracking:
-          Map.put(l.instance_tracking, instance.id, timestamp_from_iso8601(stamp))
-    }
-  end
-
-  defp remove_provider_instance(l, _source_host, pk, link_name, instance_id, _spec) do
-    provider = l.providers[{pk, link_name}]
-
-    if provider != nil do
-      provider = %Provider{
-        provider
-        | instances: provider.instances |> Enum.reject(fn i -> i.id == instance_id end)
-      }
-
-      %Lattice{
-        l
-        | providers: Map.put(l.providers, {pk, link_name}, provider),
-          instance_tracking: l.instance_tracking |> Map.delete(instance_id)
-      }
-      |> strip_instanceless_entities()
-    else
-      l
-    end
-  end
-
-  defp remove_host(l = %Lattice{}, source_host) do
-    # NOTE: the instance_tracking map will purge unseen instances
-    # during the decay event processing.
-
-    l = %Lattice{
-      l
-      | hosts: Map.delete(l.hosts, source_host),
-        actors:
-          l.actors
-          |> Enum.map(fn {k, v} ->
-            {k,
-             %Actor{
-               v
-               | instances: v.instances |> Enum.reject(fn i -> i.host_id == source_host end)
-             }}
-          end)
-          |> Enum.into(%{}),
-        providers:
-          l.providers
-          |> Enum.map(fn {k, v} ->
-            {k,
-             %Provider{
-               v
-               | instances: v.instances |> Enum.reject(fn i -> i.host_id == source_host end)
-             }}
-          end)
-          |> Enum.into(%{})
-    }
-
-    l |> strip_instanceless_entities()
-  end
-
-  defp strip_instanceless_entities(l = %Lattice{}) do
-    %Lattice{
-      l
-      | actors: l.actors |> Enum.reject(fn {_k, v} -> v.instances == [] end) |> Enum.into(%{}),
-        providers:
-          l.providers |> Enum.reject(fn {_k, v} -> v.instances == [] end) |> Enum.into(%{})
-    }
-  end
-
-  defp record_heartbeat(l = %Lattice{}, source_host, stamp, data) do
-    labels = Map.get(data, "labels", %{})
-    l = record_host(l, source_host, labels, stamp)
-
-    l =
-      List.foldl(Map.get(data, "actors", []), l, fn x, acc ->
-        # TODO - once the host can emit annotations we can pull the spec
-        put_actor_instance(acc, source_host, x["public_key"], x["instance_id"], "", stamp, %{})
-      end)
-
-    l =
-      List.foldl(Map.get(data, "providers", []), l, fn x, acc ->
-        # TODO - once the host emits annotations we can pull the spec
-        put_provider_instance(
-          acc,
-          source_host,
-          x["public_key"],
-          x["link_name"],
-          x["contract_id"],
-          x["instance_id"],
-          "",
-          stamp,
-          %{}
-        )
-      end)
-
-    l
-  end
-
-  defp record_host(l = %Lattice{}, source_host, labels, stamp) do
-    host =
-      Map.get(l.hosts, source_host, %Host{
-        id: source_host,
-        labels: labels,
-        first_seen: timestamp_from_iso8601(stamp)
-      })
-
-    # Every time we see a host, we set the last seen stamp
-    # and bump it to healthy (TODO: support aggregate status based on
-    # host contents)
-    host =
-      Map.merge(
-        host,
-        %{
-          last_seen: timestamp_from_iso8601(stamp),
-          status: :healthy
-        }
-      )
-
-    %Lattice{l | hosts: Map.put(l.hosts, source_host, host)}
-  end
-
-  @spec timestamp_from_iso8601(binary) :: DateTime.t()
-  def timestamp_from_iso8601(stamp) when is_binary(stamp) do
-    case DateTime.from_iso8601(stamp) do
-      {:ok, datetime, 0} -> datetime
-      _ -> DateTime.utc_now()
-    end
   end
 
   @spec running_instances(

--- a/test/observed/actors_test.exs
+++ b/test/observed/actors_test.exs
@@ -1,6 +1,6 @@
 defmodule LatticeObserverTest.Observed.ActorsTest do
   use ExUnit.Case
-  alias LatticeObserver.Observed.{Lattice, Instance, Actor}
+  alias LatticeObserver.Observed.{Lattice, Instance, Actor, EventProcessor}
   alias TestSupport.CloudEvents
 
   @test_spec "testapp"
@@ -12,7 +12,7 @@ defmodule LatticeObserverTest.Observed.ActorsTest do
       start = CloudEvents.actor_started("Mxxx", "abc123", @test_spec, @test_host)
       l = Lattice.new()
       l = Lattice.apply_event(l, start)
-      stamp1 = Lattice.timestamp_from_iso8601(start.time)
+      stamp1 = EventProcessor.timestamp_from_iso8601(start.time)
       # ensure idempotence
       l = Lattice.apply_event(l, start)
 
@@ -59,8 +59,8 @@ defmodule LatticeObserverTest.Observed.ActorsTest do
       l = Lattice.apply_event(l, start)
       start2 = CloudEvents.actor_started("Mxxx", "abc345", @test_spec_2, @test_host)
       l = Lattice.apply_event(l, start2)
-      stamp1 = Lattice.timestamp_from_iso8601(start.time)
-      stamp2 = Lattice.timestamp_from_iso8601(start2.time)
+      stamp1 = EventProcessor.timestamp_from_iso8601(start.time)
+      stamp2 = EventProcessor.timestamp_from_iso8601(start2.time)
 
       assert l == %Lattice{
                Lattice.new()

--- a/test/observed/hosts_test.exs
+++ b/test/observed/hosts_test.exs
@@ -1,6 +1,6 @@
 defmodule LatticeObserverTest.Observed.HostsTest do
   use ExUnit.Case
-  alias LatticeObserver.Observed.Lattice
+  alias LatticeObserver.Observed.{Lattice, EventProcessor}
   alias TestSupport.CloudEvents
 
   @test_host "Nxxx"
@@ -57,7 +57,7 @@ defmodule LatticeObserverTest.Observed.HostsTest do
           %{test: "yes"}
         )
 
-      stamp = Lattice.timestamp_from_iso8601(started.time)
+      stamp = EventProcessor.timestamp_from_iso8601(started.time)
 
       l = Lattice.apply_event(Lattice.new(), started)
       assert l.hosts[@test_host].status == :healthy
@@ -72,7 +72,7 @@ defmodule LatticeObserverTest.Observed.HostsTest do
 
     test "Properly records host heartbeat" do
       hb = CloudEvents.host_heartbeat(@test_host, %{foo: "bar", baz: "biz"})
-      stamp = Lattice.timestamp_from_iso8601(hb.time)
+      stamp = EventProcessor.timestamp_from_iso8601(hb.time)
       l = Lattice.apply_event(Lattice.new(), hb)
 
       assert l.hosts[@test_host].labels == %{baz: "biz", foo: "bar"}
@@ -80,7 +80,7 @@ defmodule LatticeObserverTest.Observed.HostsTest do
       assert l.hosts[@test_host].last_seen == stamp
 
       hb2 = CloudEvents.host_heartbeat(@test_host, %{foo: "bar", baz: "biz"})
-      stamp2 = Lattice.timestamp_from_iso8601(hb2.time)
+      stamp2 = EventProcessor.timestamp_from_iso8601(hb2.time)
       l = Lattice.apply_event(l, hb2)
 
       assert l.hosts[@test_host].labels == %{baz: "biz", foo: "bar"}

--- a/test/observed/invocation_test.exs
+++ b/test/observed/invocation_test.exs
@@ -1,0 +1,179 @@
+defmodule LatticeObserverTest.Observed.InvocationTest do
+  use ExUnit.Case
+  alias LatticeObserver.Observed.{Lattice, Invocation}
+  alias TestSupport.CloudEvents
+
+  @test_host "Nxxx"
+
+  describe "Observed invocation success and fail are recorded" do
+    test "Success and fail counts accumulate" do
+      l = Lattice.new()
+
+      evt =
+        CloudEvents.invocation_succeeded(
+          %{
+            "public_key" => "Vxxx",
+            "contract_id" => "wasmcloud:messaging",
+            "link_name" => "default"
+          },
+          %{
+            "public_key" => "Mxxx",
+            "contract_id" => nil,
+            "link_name" => " "
+          },
+          100,
+          "messaging.DeliverMessage",
+          @test_host
+        )
+
+      evt2 =
+        CloudEvents.invocation_succeeded(
+          %{
+            "public_key" => "Vxxx",
+            "contract_id" => "wasmcloud:messaging",
+            "link_name" => "default"
+          },
+          %{
+            # note the '2'
+            "public_key" => "Mxxx2",
+            "contract_id" => nil,
+            "link_name" => " "
+          },
+          500,
+          "messaging.DeliverMessage",
+          @test_host
+        )
+
+      evt3 =
+        CloudEvents.invocation_failed(
+          %{
+            "public_key" => "Vxxx",
+            "contract_id" => "wasmcloud:messaging",
+            "link_name" => "default"
+          },
+          %{
+            # note the '2'
+            "public_key" => "Mxxx2",
+            "contract_id" => nil,
+            "link_name" => " "
+          },
+          500,
+          "messaging.DeliverMessage",
+          @test_host
+        )
+
+      # Reverse an operation (show that bi-directional doesn't merge to 1 dir)
+      evt4 =
+        CloudEvents.invocation_succeeded(
+          %{
+            # note the '2'
+            "public_key" => "Mxxx2",
+            "contract_id" => nil,
+            "link_name" => " "
+          },
+          %{
+            "public_key" => "Vxxx",
+            "contract_id" => "wasmcloud:messaging",
+            "link_name" => "default"
+          },
+          500,
+          "messaging.DeliverMessage",
+          @test_host
+        )
+
+      l =
+        [evt, evt, evt2, evt3, evt4]
+        |> Enum.reduce(l, fn x, acc -> Lattice.apply_event(acc, x) end)
+
+      assert {:ok,
+              %Invocation.InvocationLog{
+                fail_count: 0,
+                from: %Invocation.Entity{
+                  contract_id: "wasmcloud:messaging",
+                  link_name: "default",
+                  public_key: "Vxxx"
+                },
+                operation: "messaging.DeliverMessage",
+                success_count: 2,
+                to: %Invocation.Entity{
+                  contract_id: nil,
+                  link_name: nil,
+                  public_key: "Mxxx"
+                },
+                total_bytes: 200
+              }} ==
+               Lattice.lookup_invocation_log(
+                 l,
+                 %Invocation.Entity{
+                   public_key: "Vxxx",
+                   contract_id: "wasmcloud:messaging",
+                   link_name: "default"
+                 },
+                 %Invocation.Entity{
+                   public_key: "Mxxx",
+                   contract_id: nil,
+                   link_name: nil
+                 },
+                 "messaging.DeliverMessage"
+               )
+
+      assert {:ok,
+              %Invocation.InvocationLog{
+                fail_count: 1,
+                from: %Invocation.Entity{
+                  contract_id: "wasmcloud:messaging",
+                  link_name: "default",
+                  public_key: "Vxxx"
+                },
+                operation: "messaging.DeliverMessage",
+                success_count: 1,
+                to: %Invocation.Entity{contract_id: nil, link_name: nil, public_key: "Mxxx2"},
+                total_bytes: 1000
+              }} ==
+               Lattice.lookup_invocation_log(
+                 l,
+                 %Invocation.Entity{
+                   public_key: "Vxxx",
+                   contract_id: "wasmcloud:messaging",
+                   link_name: "default"
+                 },
+                 %Invocation.Entity{
+                   ## note the '2' here
+                   public_key: "Mxxx2",
+                   contract_id: nil,
+                   link_name: nil
+                 },
+                 "messaging.DeliverMessage"
+               )
+
+      assert {:ok,
+              %Invocation.InvocationLog{
+                fail_count: 0,
+                from: %Invocation.Entity{contract_id: nil, link_name: nil, public_key: "Mxxx2"},
+                operation: "messaging.DeliverMessage",
+                success_count: 1,
+                to: %Invocation.Entity{
+                  contract_id: "wasmcloud:messaging",
+                  link_name: "default",
+                  public_key: "Vxxx"
+                },
+                total_bytes: 500
+              }} ==
+               Lattice.lookup_invocation_log(
+                 l,
+                 %Invocation.Entity{
+                   ## note the '2' here
+                   public_key: "Mxxx2",
+                   contract_id: nil,
+                   link_name: nil
+                 },
+                 %Invocation.Entity{
+                   public_key: "Vxxx",
+                   contract_id: "wasmcloud:messaging",
+                   link_name: "default"
+                 },
+                 "messaging.DeliverMessage"
+               )
+    end
+  end
+end

--- a/test/observed/linkdefs_test.exs
+++ b/test/observed/linkdefs_test.exs
@@ -1,6 +1,6 @@
 defmodule LatticeObserverTest.Observed.LinkdefsTest do
   use ExUnit.Case
-  alias LatticeObserver.Observed.{Lattice, EventProcessor}
+  alias LatticeObserver.Observed.Lattice
   alias TestSupport.CloudEvents
 
   describe "Observed Lattice Monitors Linkdef Events" do

--- a/test/observed/linkdefs_test.exs
+++ b/test/observed/linkdefs_test.exs
@@ -1,6 +1,6 @@
 defmodule LatticeObserverTest.Observed.LinkdefsTest do
   use ExUnit.Case
-  alias LatticeObserver.Observed.Lattice
+  alias LatticeObserver.Observed.{Lattice, EventProcessor}
   alias TestSupport.CloudEvents
 
   describe "Observed Lattice Monitors Linkdef Events" do

--- a/test/observed/providers_test.exs
+++ b/test/observed/providers_test.exs
@@ -1,6 +1,6 @@
 defmodule LatticeObserverTest.Observed.ProvidersTest do
   use ExUnit.Case
-  alias LatticeObserver.Observed.{Lattice, Instance, Provider}
+  alias LatticeObserver.Observed.{Lattice, Instance, Provider, EventProcessor}
   alias TestSupport.CloudEvents
 
   @test_spec "testapp"
@@ -22,7 +22,7 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
 
       l = Lattice.new()
       l = Lattice.apply_event(l, start)
-      stamp1 = Lattice.timestamp_from_iso8601(start.time)
+      stamp1 = EventProcessor.timestamp_from_iso8601(start.time)
       # ensure idempotence
       l = Lattice.apply_event(l, start)
 
@@ -101,7 +101,7 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
           @test_host
         )
 
-      stamp = Lattice.timestamp_from_iso8601(start.time)
+      stamp = EventProcessor.timestamp_from_iso8601(start.time)
       l = Lattice.apply_event(Lattice.new(), start)
 
       start2 =
@@ -114,7 +114,7 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
           @test_host
         )
 
-      stamp2 = Lattice.timestamp_from_iso8601(start2.time)
+      stamp2 = EventProcessor.timestamp_from_iso8601(start2.time)
       l = Lattice.apply_event(l, start2)
 
       assert l == %Lattice{
@@ -159,7 +159,7 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
           @test_host
         )
 
-      stamp3 = Lattice.timestamp_from_iso8601(start3.time)
+      stamp3 = EventProcessor.timestamp_from_iso8601(start3.time)
 
       l = Lattice.apply_event(l, start3)
 

--- a/test/support/cloud_events.ex
+++ b/test/support/cloud_events.ex
@@ -131,4 +131,24 @@ defmodule TestSupport.CloudEvents do
     }
     |> LatticeObserver.CloudEvent.new("linkdef_deleted", host)
   end
+
+  def invocation_succeeded(from = %{}, to = %{}, bytes, operation, host) do
+    %{
+      "source" => from,
+      "dest" => to,
+      "operation" => operation,
+      "bytes" => bytes
+    }
+    |> LatticeObserver.CloudEvent.new("invocation_succeeded", host)
+  end
+
+  def invocation_failed(from = %{}, to = %{}, bytes, operation, host) do
+    %{
+      "source" => from,
+      "dest" => to,
+      "operation" => operation,
+      "bytes" => bytes
+    }
+    |> LatticeObserver.CloudEvent.new("invocation_failed", host)
+  end
 end


### PR DESCRIPTION
This allows a lattice observer to maintain an aggregate log of invocations, keeping track of the `from` and `to` values of each invocation, whether they succeed or fail, and the total bytes of all invocations.