### PR TITLE
Support storing and applying claims

### DIFF
--- a/lib/lattice_observer/observed/actor.ex
+++ b/lib/lattice_observer/observed/actor.ex
@@ -3,7 +3,7 @@ defmodule LatticeObserver.Observed.Actor do
   alias LatticeObserver.Observed.Instance
 
   @enforce_keys [:id, :name]
-  defstruct [:id, :name, :capabilities, :issuer, :tags, :call_alias, :version, :instances]
+  defstruct [:id, :name, :capabilities, :issuer, :tags, :call_alias, :instances]
 
   @typedoc """
   An actor observed through event receipt within the lattice.
@@ -17,4 +17,16 @@ defmodule LatticeObserver.Observed.Actor do
           call_alias: String.t(),
           instances: [Instance.t()]
         }
+
+  def new(id, name) when is_binary(id) and is_binary(name) do
+    %Actor{
+      id: id,
+      name: name,
+      instances: [],
+      capabilities: [],
+      issuer: "",
+      call_alias: "",
+      tags: ""
+    }
+  end
 end

--- a/lib/lattice_observer/observed/claims.ex
+++ b/lib/lattice_observer/observed/claims.ex
@@ -1,0 +1,110 @@
+defmodule LatticeObserver.Observed.Claims do
+  require Logger
+  alias __MODULE__
+  alias LatticeObserver.Observed.{Lattice, Provider, Actor}
+
+  @enforce_keys [:sub]
+  defstruct [
+    :sub,
+    :call_alias,
+    :iss,
+    :name,
+    :caps,
+    :rev,
+    :tags,
+    :version
+  ]
+
+  @type t :: %Claims{
+          sub: String.t(),
+          call_alias: String.t(),
+          iss: String.t(),
+          name: String.t(),
+          # Comma-delimited list
+          caps: String.t(),
+          rev: String.t(),
+          # Comma-delimited list
+          tags: String.t(),
+          version: String.t()
+        }
+
+  # Apply a capability provider's claims
+  @spec apply(Lattice.t(), Claims.t()) :: Lattice.t()
+  def apply(
+        l = %Lattice{},
+        claims = %Claims{
+          sub: public_key = "V" <> _rest,
+          iss: issuer,
+          name: name,
+          tags: tags
+        }
+      ) do
+    l = %Lattice{l | claims: l.claims |> Map.put(public_key, claims)}
+
+    provs =
+      l.providers
+      |> Enum.map(fn {key = {pk, _ln}, prov} ->
+        # IO.inspect(key)
+        # IO.inspect(prov)
+        if public_key == pk do
+          {key, %Provider{prov | name: name, issuer: issuer, tags: tags |> String.split(",")}}
+        else
+          {key, prov}
+        end
+      end)
+      |> Enum.into(%{})
+
+    %Lattice{l | providers: provs}
+    # l =
+    #   case l.providers |> Map.get({public_key, link_name}) do
+    #     nil ->
+    #       # Please disperse, nothing to see here.
+    #       l
+
+    #     p ->
+    #       p = %Provider{p | name: name, tags: tags |> String.split(","), issuer: issuer}
+    #       %Lattice{l | providers: l.providers |> Map.put({public_key, link_name}, p)}
+    #   end
+  end
+
+  # Apply an actor's claims
+  def apply(
+        l = %Lattice{},
+        claims = %Claims{
+          sub: public_key = "M" <> _rest,
+          iss: issuer,
+          name: name,
+          caps: caps,
+          call_alias: call_alias,
+          tags: tags
+        }
+      ) do
+    l = %Lattice{l | claims: l.claims |> Map.put(public_key, claims)}
+
+    l =
+      case l.actors |> Map.get(public_key) do
+        nil ->
+          # Please disperse, nothing to see here.
+          l
+
+        a ->
+          a = %Actor{
+            a
+            | name: name,
+              capabilities: caps |> String.split(","),
+              issuer: issuer,
+              call_alias: call_alias,
+              tags: tags
+          }
+
+          %Lattice{l | actors: l.actors |> Map.put(public_key, a)}
+      end
+
+    l
+  end
+
+  def apply(l = %Lattice{}, claims = %Claims{}) do
+    Logger.warn("Unexpected claims data: #{inspect(claims)}")
+    l
+  end
+end

--- a/lib/lattice_observer/observed/claims.ex
+++ b/lib/lattice_observer/observed/claims.ex
@@ -3,7 +3,7 @@ defmodule LatticeObserver.Observed.Claims do
   alias __MODULE__
   alias LatticeObserver.Observed.{Lattice, Provider, Actor}
 
-  @enforce_keys [:sub]
+  @enforce_keys [:sub, :iss]
   defstruct [
     :sub,
     :call_alias,
@@ -44,8 +44,6 @@ defmodule LatticeObserver.Observed.Claims do
     provs =
       l.providers
       |> Enum.map(fn {key = {pk, _ln}, prov} ->
-        # IO.inspect(key)
-        # IO.inspect(prov)
         if public_key == pk do
           {key, %Provider{prov | name: name, issuer: issuer, tags: tags |> String.split(",")}}
         else
@@ -55,16 +53,6 @@ defmodule LatticeObserver.Observed.Claims do
       |> Enum.into(%{})
 
     %Lattice{l | providers: provs}
-    # l =
-    #   case l.providers |> Map.get({public_key, link_name}) do
-    #     nil ->
-    #       # Please disperse, nothing to see here.
-    #       l
-
-    #     p ->
-    #       p = %Provider{p | name: name, tags: tags |> String.split(","), issuer: issuer}
-    #       %Lattice{l | providers: l.providers |> Map.put({public_key, link_name}, p)}
-    #   end
   end
 
   # Apply an actor's claims

--- a/lib/lattice_observer/observed/provider.ex
+++ b/lib/lattice_observer/observed/provider.ex
@@ -3,7 +3,7 @@ defmodule LatticeObserver.Observed.Provider do
   alias LatticeObserver.Observed.Instance
 
   @enforce_keys [:id, :contract_id, :link_name, :instances]
-  defstruct [:id, :name, :issuer, :version, :contract_id, :tags, :link_name, :instances]
+  defstruct [:id, :name, :issuer, :contract_id, :tags, :link_name, :instances]
 
   @typedoc """
   A representation of an observed capability provider. Providers are uniquely

--- a/test/observed/claims_test.exs
+++ b/test/observed/claims_test.exs
@@ -1,0 +1,139 @@
+defmodule LatticeObserverTest.Observed.ClaimsTest do
+  use ExUnit.Case
+  alias LatticeObserver.Observed.{Lattice, Instance, Claims}
+  alias TestSupport.CloudEvents
+
+  describe "Claims cache works appropriately" do
+    test "Applying claims updates the cache" do
+      l = Lattice.new()
+
+      l =
+        Lattice.apply_claims(l, %Claims{
+          sub: "Mxxxx",
+          iss: "Axxxx",
+          call_alias: "test/bob",
+          caps: "wasmcloud:test,wasmcloud:othertest",
+          rev: "0",
+          tags: "test,othertest",
+          version: "0.1",
+          name: "Super ultra mega test"
+        })
+
+      assert l.claims == %{
+               "Mxxxx" => %Claims{
+                 sub: "Mxxxx",
+                 iss: "Axxxx",
+                 call_alias: "test/bob",
+                 caps: "wasmcloud:test,wasmcloud:othertest",
+                 rev: "0",
+                 tags: "test,othertest",
+                 version: "0.1",
+                 name: "Super ultra mega test"
+               }
+             }
+    end
+
+    # In this scenario, we have discovered actors/providers through partial data - e.g. we didn't see
+    # the actor started event, but we saw the public key come through on a heartbeat. When we apply
+    # claims after the fact, we should update the metadata to include friendly names, call aliases, etc.
+    test "Applying claims with heartbeat-only-discovered actors and providers updates metadata" do
+      hb =
+        CloudEvents.host_heartbeat(
+          "Nxxxx",
+          %{foo: "bar", baz: "biz"},
+          [
+            %{
+              "public_key" => "Mxxxx",
+              "instance_id" => "42"
+            }
+          ],
+          [
+            %{
+              "contract_id" => "wasmcloud:test",
+              "instance_id" => "43",
+              "link_name" => "default",
+              "public_key" => "Vxxxx"
+            }
+          ]
+        )
+
+      l = Lattice.new() |> Lattice.apply_event(hb)
+
+      aclaims = %Claims{
+        sub: "Mxxxx",
+        name: "Super ultra mega actor",
+        iss: "Axxxx",
+        call_alias: "test/bob",
+        caps: "wasmcloud:test,wasmcloud:othertest",
+        rev: "0",
+        tags: "test,othertest",
+        version: "0.1"
+      }
+
+      vclaims = %Claims{
+        name: "Super ultra mega provider",
+        sub: "Vxxxx",
+        iss: "Axxxx",
+        rev: "0",
+        tags: "test,othertest",
+        version: "0.1"
+      }
+
+      l = l |> Lattice.apply_claims(aclaims) |> Lattice.apply_claims(vclaims)
+
+      assert l.actors |> Map.get("Mxxxx")
+    end
+
+    test "Receiving heartbeats after applying claims augments data" do
+      l = Lattice.new()
+
+      aclaims = %Claims{
+        sub: "Mxxxx",
+        name: "Super ultra mega actor",
+        iss: "Axxxx",
+        call_alias: "test/bob",
+        caps: "wasmcloud:test,wasmcloud:othertest",
+        rev: "0",
+        tags: "test,othertest",
+        version: "0.1"
+      }
+
+      vclaims = %Claims{
+        name: "Super ultra mega provider",
+        sub: "Vxxxx",
+        iss: "Axxxx",
+        rev: "0",
+        tags: "test,othertest",
+        version: "0.1"
+      }
+
+      l = l |> Lattice.apply_claims(aclaims) |> Lattice.apply_claims(vclaims)
+
+      hb =
+        CloudEvents.host_heartbeat(
+          "Nxxxx",
+          %{foo: "bar", baz: "biz"},
+          [
+            %{
+              "public_key" => "Mxxxx",
+              "instance_id" => "42"
+            }
+          ],
+          [
+            %{
+              "contract_id" => "wasmcloud:test",
+              "instance_id" => "43",
+              "link_name" => "default",
+              "public_key" => "Vxxxx"
+            }
+          ]
+        )
+
+      # NOTE - claims arrived first, got cached, then heartbeat arrived with no metadata
+      # about providers or actors, lattice observer augmented from the cache.
+      l = l |> Lattice.apply_event(hb)
+      assert Map.get(l.providers, {"Vxxxx", "default"}).name == "Super ultra mega provider"
+      assert Map.get(l.actors, "Mxxxx").call_alias == "test/bob"
+    end
+  end
+end

--- a/test/observed/hosts_test.exs
+++ b/test/observed/hosts_test.exs
@@ -133,8 +133,7 @@ defmodule LatticeObserverTest.Observed.HostsTest do
                  ],
                  issuer: "",
                  name: "unavailable",
-                 tags: [],
-                 version: nil
+                 tags: []
                },
                "Mxxxy" => %LatticeObserver.Observed.Actor{
                  call_alias: "",
@@ -151,8 +150,7 @@ defmodule LatticeObserverTest.Observed.HostsTest do
                  ],
                  issuer: "",
                  name: "unavailable",
-                 tags: [],
-                 version: nil
+                 tags: []
                }
              }
 
@@ -172,8 +170,7 @@ defmodule LatticeObserverTest.Observed.HostsTest do
                  issuer: "",
                  link_name: "default",
                  name: "unavailable",
-                 tags: [],
-                 version: nil
+                 tags: []
                }
              }
     end

--- a/test/observed/providers_test.exs
+++ b/test/observed/providers_test.exs
@@ -47,8 +47,7 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
               issuer: "ATESTxxx",
               link_name: "default",
               name: "test provider",
-              tags: ["a", "b"],
-              version: nil
+              tags: ["a", "b"]
             }
           }
       }


### PR DESCRIPTION
In this PR, the lattice observer gains a new function `apply_claims` which takes a new struct (`%Claims{}`). These claims are immediately applied to the current contents of the observed lattice and then when heartbeats come into the lattice, the contents of the claims are used to augment the data on those heartbeats.

This has the net effect of allowing a consumer to start observing a lattice after all of the actor/provider started events have been published and, with the appropriate claims, rebuild a clean inventory from a set of heartbeats without having to resort to displaying "unavailable" (or worse, "") in description fields.