### PR TITLE
Apply claims on start events

### DIFF
--- a/lib/lattice_observer/observed/actor.ex
+++ b/lib/lattice_observer/observed/actor.ex
@@ -2,7 +2,7 @@ defmodule LatticeObserver.Observed.Actor do
   alias __MODULE__
   alias LatticeObserver.Observed.Instance
 
-  @enforce_keys [:id, :name]
+  @enforce_keys [:id, :name, :instances]
   defstruct [:id, :name, :capabilities, :issuer, :tags, :call_alias, :instances]
 
   @typedoc """
@@ -22,11 +22,7 @@ defmodule LatticeObserver.Observed.Actor do
     %Actor{
       id: id,
       name: name,
-      instances: [],
-      capabilities: [],
-      issuer: "",
-      call_alias: "",
-      tags: ""
+      instances: []
     }
   end
 end

--- a/lib/lattice_observer/observed/claims.ex
+++ b/lib/lattice_observer/observed/claims.ex
@@ -45,7 +45,7 @@ defmodule LatticeObserver.Observed.Claims do
       l.providers
       |> Enum.map(fn {key = {pk, _ln}, prov} ->
         if public_key == pk do
-          {key, %Provider{prov | name: name, issuer: issuer, tags: tags |> String.split(",")}}
+          {key, %Provider{prov | name: name, issuer: issuer, tags: tags |> safesplit()}}
         else
           {key, prov}
         end
@@ -95,4 +95,8 @@ defmodule LatticeObserver.Observed.Claims do
     Logger.warn("Unexpected claims data: #{inspect(claims)}")
     l
   end
+
+  defp safesplit(nil), do: []
+  defp safesplit([]), do: []
+  defp safesplit(str), do: String.split(str, ",")
 end

--- a/lib/lattice_observer/observed/lattice.ex
+++ b/lib/lattice_observer/observed/lattice.ex
@@ -262,6 +262,17 @@ defmodule LatticeObserver.Observed.Lattice do
     spec = Map.get(annotations, @annotation_app_spec, "")
     claims = Map.get(d, "claims", %{})
 
+    apply_claims(l, %Claims{
+      iss: Map.get(claims, "issuer", "N/A"),
+      tags: Map.get(claims, "tags", ""),
+      name: Map.get(claims, "name", "unavailable"),
+      version: Map.get(claims, "version", ""),
+      call_alias: "",
+      caps: "",
+      rev: "",
+      sub: pk
+    })
+
     EventProcessor.put_provider_instance(
       l,
       source_host,
@@ -341,6 +352,18 @@ defmodule LatticeObserver.Observed.Lattice do
       ) do
     spec = Map.get(d, "annotations", %{}) |> Map.get(@annotation_app_spec, "")
     claims = Map.get(d, "claims", %{})
+
+    apply_claims(l, %Claims{
+      call_alias: Map.get(claims, "call_alias", ""),
+      iss: Map.get(claims, "issuer", "N/A"),
+      name: Map.get(claims, "name", ""),
+      caps: Map.get(claims, "caps", ""),
+      rev: Map.get(claims, "revision", ""),
+      tags: Map.get(claims, "tags", ""),
+      version: Map.get(claims, "version", ""),
+      sub: pk
+    })
+
     EventProcessor.put_actor_instance(l, source_host, pk, instance_id, spec, stamp, claims)
   end
 

--- a/lib/lattice_observer/observed/lattice.ex
+++ b/lib/lattice_observer/observed/lattice.ex
@@ -262,16 +262,15 @@ defmodule LatticeObserver.Observed.Lattice do
     spec = Map.get(annotations, @annotation_app_spec, "")
     claims = Map.get(d, "claims", %{})
 
-    apply_claims(l, %Claims{
-      iss: Map.get(claims, "issuer", "N/A"),
-      tags: Map.get(claims, "tags", ""),
-      name: Map.get(claims, "name", "unavailable"),
-      version: Map.get(claims, "version", ""),
-      call_alias: "",
-      caps: "",
-      rev: "",
-      sub: pk
-    })
+    l =
+      apply_claims(l, %Claims{
+        iss: Map.get(claims, "issuer", "N/A"),
+        tags: Map.get(claims, "tags", ""),
+        name: Map.get(claims, "name", "unavailable"),
+        version: Map.get(claims, "version", ""),
+        rev: Map.get(claims, "revision", "0"),
+        sub: pk
+      })
 
     EventProcessor.put_provider_instance(
       l,
@@ -353,16 +352,17 @@ defmodule LatticeObserver.Observed.Lattice do
     spec = Map.get(d, "annotations", %{}) |> Map.get(@annotation_app_spec, "")
     claims = Map.get(d, "claims", %{})
 
-    apply_claims(l, %Claims{
-      call_alias: Map.get(claims, "call_alias", ""),
-      iss: Map.get(claims, "issuer", "N/A"),
-      name: Map.get(claims, "name", ""),
-      caps: Map.get(claims, "caps", ""),
-      rev: Map.get(claims, "revision", ""),
-      tags: Map.get(claims, "tags", ""),
-      version: Map.get(claims, "version", ""),
-      sub: pk
-    })
+    l =
+      apply_claims(l, %Claims{
+        call_alias: Map.get(claims, "call_alias", ""),
+        iss: Map.get(claims, "issuer", "N/A"),
+        name: Map.get(claims, "name", ""),
+        caps: Map.get(claims, "caps", []) |> Enum.join(","),
+        rev: Map.get(claims, "revision", ""),
+        tags: Map.get(claims, "tags", ""),
+        version: Map.get(claims, "version", ""),
+        sub: pk
+      })
 
     EventProcessor.put_actor_instance(l, source_host, pk, instance_id, spec, stamp, claims)
   end

--- a/lib/lattice_observer/observed/provider.ex
+++ b/lib/lattice_observer/observed/provider.ex
@@ -20,12 +20,13 @@ defmodule LatticeObserver.Observed.Provider do
           instances: [Instance.t()]
         }
 
-  def new(id, link_name, contract_id, instances \\ []) do
+  def new(id, link_name, contract_id, instances \\ [], tags \\ []) do
     %Provider{
       id: id,
       link_name: link_name,
       contract_id: contract_id,
-      instances: instances
+      instances: instances,
+      tags: tags
     }
   end
 end


### PR DESCRIPTION
Previously we would merge actors and providers with their claims information but discard the claims data. This causes host heartbeats and future lattice events that don't have complete information about their actors and providers to show "unavailable" for some claims information.