### PR TITLE
Clear multiple identical hosts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,70 @@
+name: Lattice Observer Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  MIX_ENV: test
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, windows-2022, macos-11]
+        elixir: [1.13.4]
+        otp: [25]
+
+    name: Build and test
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # Install erlang/OTP and elixir
+      - name: Install erlang and elixir
+        if: ${{ startswith(matrix.os, 'ubuntu') || startswith(matrix.os, 'windows') }}
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: "=${{ matrix.otp }}"
+          elixir-version: ${{ matrix.elixir }}
+          install-hex: true
+          install-rebar: true
+      - name: Install erlang and elixir
+        if: ${{ startswith(matrix.os, 'macos') }}
+        run: |
+          brew install erlang
+          brew install elixir
+          mix local.rebar --force
+          mix local.hex --force
+
+      - name: Retrieve Mix Dependencies Cache
+        uses: actions/cache@v2
+        id: mix-cache #id to use in retrieve action
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles('mix.exs', 'mix.lock') }}
+
+      - name: Install Mix Dependencies
+        if: steps.mix-cache.outputs.cache-hit != 'true'
+        run: |
+          mix do deps.get, deps.compile
+
+      - name: Check Formatting
+        if: ${{ !startswith(matrix.os, 'windows') }} # Windows gets angry about carriage returns
+        run: mix format --check-formatted
+
+      - name: Run NATS for tests
+        uses: wasmcloud/common-actions/run-nats@main
+        if: ${{ startswith(matrix.os, 'ubuntu') }} # Run on Ubuntu only as a temporary workaround to dependencies that aren't present on windows/mac runners
+
+      - name: Run Tests
+        if: ${{ startswith(matrix.os, 'ubuntu') }} # Run on Ubuntu only as a temporary workaround to dependencies that aren't present on windows/mac runners
+        env:
+          MIX_ENV: test
+        run: mix test

--- a/lib/lattice_observer/observed/claims.ex
+++ b/lib/lattice_observer/observed/claims.ex
@@ -45,7 +45,7 @@ defmodule LatticeObserver.Observed.Claims do
       l.providers
       |> Enum.map(fn {key = {pk, _ln}, prov} ->
         if public_key == pk do
-          {key, %Provider{prov | name: name, issuer: issuer, tags: tags |> safesplit()}}
+          {key, %Provider{prov | name: name, issuer: issuer, tags: tags |> safesplit_tags()}}
         else
           {key, prov}
         end
@@ -96,7 +96,8 @@ defmodule LatticeObserver.Observed.Claims do
     l
   end
 
-  defp safesplit(nil), do: []
-  defp safesplit([]), do: []
-  defp safesplit(str), do: String.split(str, ",")
+  defp safesplit_tags(nil), do: ""
+  defp safesplit_tags(list) when is_list(list), do: list |> Enum.join(",")
+  defp safesplit_tags(str) when is_binary(str), do: str
+  defp safesplit_tags(_), do: ""
 end

--- a/lib/lattice_observer/observed/lattice.ex
+++ b/lib/lattice_observer/observed/lattice.ex
@@ -144,7 +144,14 @@ defmodule LatticeObserver.Observed.Lattice do
       ) do
     labels = Map.get(data, "labels", %{})
     friendly_name = Map.get(data, "friendly_name", "")
-    EventProcessor.record_host(l, source_host, labels, stamp, friendly_name)
+    # First, remove any leftover host artifacts from the lattice,
+    # then record the host started event.
+    #
+    # This is a preventative measure to ensure that a host that restarts due to unexpected
+    # circumstances (e.g. getting kill -9'ed) and retains the same host key properly
+    # clears the cache.
+    EventProcessor.remove_host(l, source_host)
+    |> EventProcessor.record_host(source_host, labels, stamp, friendly_name)
   end
 
   def apply_event(

--- a/lib/lattice_observer/observed/provider.ex
+++ b/lib/lattice_observer/observed/provider.ex
@@ -15,7 +15,7 @@ defmodule LatticeObserver.Observed.Provider do
           name: String.t(),
           issuer: String.t(),
           contract_id: String.t(),
-          tags: [String.t()],
+          tags: String.t(),
           link_name: String.t(),
           instances: [Instance.t()]
         }

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LatticeObserver.MixProject do
   def project do
     [
       app: :lattice_observer,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.12",
       elixirc_paths: compiler_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/observed/actors_test.exs
+++ b/test/observed/actors_test.exs
@@ -34,7 +34,19 @@ defmodule LatticeObserverTest.Observed.ActorsTest do
                      ],
                      issuer: "ATESTxxx",
                      name: "Test Actor",
-                     tags: []
+                     tags: ""
+                   }
+                 },
+                 claims: %{
+                   "Mxxx" => %LatticeObserver.Observed.Claims{
+                     call_alias: "",
+                     caps: "test,test2",
+                     iss: "ATESTxxx",
+                     name: "Test Actor",
+                     rev: 0,
+                     sub: "Mxxx",
+                     tags: "",
+                     version: "1.0"
                    }
                  },
                  instance_tracking: %{
@@ -49,7 +61,19 @@ defmodule LatticeObserverTest.Observed.ActorsTest do
 
       assert l == %Lattice{
                Lattice.new()
-               | actors: %{}
+               | actors: %{},
+                 claims: %{
+                   "Mxxx" => %LatticeObserver.Observed.Claims{
+                     call_alias: "",
+                     caps: "test,test2",
+                     iss: "ATESTxxx",
+                     name: "Test Actor",
+                     rev: 0,
+                     sub: "Mxxx",
+                     tags: "",
+                     version: "1.0"
+                   }
+                 }
              }
     end
 
@@ -87,7 +111,19 @@ defmodule LatticeObserverTest.Observed.ActorsTest do
                      ],
                      issuer: "ATESTxxx",
                      name: "Test Actor",
-                     tags: []
+                     tags: ""
+                   }
+                 },
+                 claims: %{
+                   "Mxxx" => %LatticeObserver.Observed.Claims{
+                     call_alias: "",
+                     caps: "test,test2",
+                     iss: "ATESTxxx",
+                     name: "Test Actor",
+                     rev: 0,
+                     sub: "Mxxx",
+                     tags: "",
+                     version: "1.0"
                    }
                  },
                  instance_tracking: %{
@@ -121,7 +157,19 @@ defmodule LatticeObserverTest.Observed.ActorsTest do
                      ],
                      issuer: "ATESTxxx",
                      name: "Test Actor",
-                     tags: []
+                     tags: ""
+                   }
+                 },
+                 claims: %{
+                   "Mxxx" => %LatticeObserver.Observed.Claims{
+                     call_alias: "",
+                     caps: "test,test2",
+                     iss: "ATESTxxx",
+                     name: "Test Actor",
+                     rev: 0,
+                     sub: "Mxxx",
+                     tags: "",
+                     version: "1.0"
                    }
                  },
                  instance_tracking: %{

--- a/test/observed/providers_test.exs
+++ b/test/observed/providers_test.exs
@@ -31,6 +31,18 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
         | instance_tracking: %{
             "abc123" => stamp1
           },
+          claims: %{
+            "Vxxx" => %LatticeObserver.Observed.Claims{
+              call_alias: nil,
+              caps: nil,
+              iss: "ATESTxxx",
+              name: "test provider",
+              rev: 2,
+              sub: "Vxxx",
+              tags: "a,b",
+              version: "1.0"
+            }
+          },
           providers: %{
             {"Vxxx", "default"} => %Provider{
               contract_id: "wasmcloud:test",
@@ -47,7 +59,7 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
               issuer: "ATESTxxx",
               link_name: "default",
               name: "test provider",
-              tags: ["a", "b"]
+              tags: "a,b"
             }
           }
       }
@@ -79,7 +91,19 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
 
       desired = %Lattice{
         Lattice.new()
-        | providers: %{}
+        | providers: %{},
+          claims: %{
+            "Vxxx" => %LatticeObserver.Observed.Claims{
+              call_alias: nil,
+              caps: nil,
+              iss: "ATESTxxx",
+              name: "test provider",
+              rev: 2,
+              sub: "Vxxx",
+              tags: "a,b",
+              version: "1.0"
+            }
+          }
       }
 
       assert l == desired
@@ -142,7 +166,19 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
                      issuer: "ATESTxxx",
                      link_name: "default",
                      name: "test provider",
-                     tags: ["a", "b"]
+                     tags: "a,b"
+                   }
+                 },
+                 claims: %{
+                   "Vxxx" => %LatticeObserver.Observed.Claims{
+                     call_alias: nil,
+                     caps: nil,
+                     iss: "ATESTxxx",
+                     name: "test provider",
+                     rev: 2,
+                     sub: "Vxxx",
+                     tags: "a,b",
+                     version: "1.0"
                    }
                  }
              }
@@ -174,7 +210,7 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
                      contract_id: "wasmcloud:test",
                      issuer: "ATESTxxx",
                      name: "test provider",
-                     tags: ["a", "b"],
+                     tags: "a,b",
                      id: "Vxxx",
                      instances: [
                        %Instance{
@@ -200,6 +236,18 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
                        }
                      ],
                      link_name: "default"
+                   }
+                 },
+                 claims: %{
+                   "Vxxx" => %LatticeObserver.Observed.Claims{
+                     call_alias: nil,
+                     caps: nil,
+                     iss: "ATESTxxx",
+                     name: "test provider",
+                     rev: 2,
+                     sub: "Vxxx",
+                     tags: "a,b",
+                     version: "1.0"
                    }
                  }
              }

--- a/test/support/cloud_events.ex
+++ b/test/support/cloud_events.ex
@@ -35,7 +35,7 @@ defmodule TestSupport.CloudEvents do
         "caps" => ["test", "test2"],
         "version" => "1.0",
         "revision" => 0,
-        "tags" => [],
+        "tags" => "",
         "issuer" => "ATESTxxx"
       }
     }
@@ -86,7 +86,7 @@ defmodule TestSupport.CloudEvents do
         "version" => "1.0",
         "revision" => 2,
         "issuer" => "ATESTxxx",
-        "tags" => ["a", "b"]
+        "tags" => "a,b"
       }
     }
     |> LatticeObserver.CloudEvent.new("provider_started", host)


### PR DESCRIPTION
This PR
1. Adds a test pipeline for the lattice observer
2. Updates some failing tests
3. refactors the caps and tags to ensure that caps is a list of strings and tags are a comma separated list of tags (this is how it's represented in the host claims). This was only done to make tests work

And, most importantly, ensures that the `host_started` event clears out the lattice cache of any potentially remaining resources for that host. For 99% of the `host_started` events that are received this will be a no-op, however, in special cases where a host restarts un-gracefully (e.g. by forcefully killing the host) and the same host is restarted using the private key seed, this ensures that the lattice observer wipes the old state clean from the host.

This does _not_ apply for scenarios where new hosts are launched with a different private key. Decaying hosts, when they fully decay out of the lattice, will remove their leftover resources (which they don't do now, will be tackled in a separate PR)