### PR TITLE
Upgrading to support heartbeats from the 0.60+ host

### DIFF
--- a/lib/lattice_observer/observed/event_processor.ex
+++ b/lib/lattice_observer/observed/event_processor.ex
@@ -251,6 +251,8 @@ defmodule LatticeObserver.Observed.EventProcessor do
 
     # legacy heartbeat has a list for the actors field...
     # default to "new format" if this field is missing
+    # TODO - once a few wasmCloud OTP releases have gone by with the new heartbeat format, stop
+    # parsing/processing the legacy structure
     l =
       if is_list(Map.get(data, "actors", %{})) do
         put_legacy_instances(l, source_host, spec, stamp, data)
@@ -279,7 +281,7 @@ defmodule LatticeObserver.Observed.EventProcessor do
             source_host,
             x["public_key"],
             x["link_name"],
-            "n/a",
+            Map.get(x, "contract_id", "n/a"),
             "n/a",
             spec,
             stamp,

--- a/lib/lattice_observer/observed/event_processor.ex
+++ b/lib/lattice_observer/observed/event_processor.ex
@@ -250,8 +250,9 @@ defmodule LatticeObserver.Observed.EventProcessor do
     l = record_host(l, source_host, labels, stamp, friendly_name)
 
     # legacy heartbeat has a list for the actors field...
+    # default to "new format" if this field is missing
     l =
-      if is_list(Map.get(data, "actors")) do
+      if is_list(Map.get(data, "actors", %{})) do
         put_legacy_instances(l, source_host, spec, stamp, data)
       else
         actors_expanded =

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LatticeObserver.MixProject do
   def project do
     [
       app: :lattice_observer,
-      version: "0.2.3",
+      version: "0.3.0",
       elixir: "~> 1.12",
       elixirc_paths: compiler_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LatticeObserver.MixProject do
   def project do
     [
       app: :lattice_observer,
-      version: "0.2.2",
+      version: "0.2.3",
       elixir: "~> 1.12",
       elixirc_paths: compiler_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/observed/claims_test.exs
+++ b/test/observed/claims_test.exs
@@ -41,16 +41,9 @@ defmodule LatticeObserverTest.Observed.ClaimsTest do
         CloudEvents.host_heartbeat(
           "Nxxxx",
           %{foo: "bar", baz: "biz"},
+          %{"Mxxxx" => 1},
           [
             %{
-              "public_key" => "Mxxxx",
-              "instance_id" => "42"
-            }
-          ],
-          [
-            %{
-              "contract_id" => "wasmcloud:test",
-              "instance_id" => "43",
               "link_name" => "default",
               "public_key" => "Vxxxx"
             }
@@ -113,16 +106,9 @@ defmodule LatticeObserverTest.Observed.ClaimsTest do
         CloudEvents.host_heartbeat(
           "Nxxxx",
           %{foo: "bar", baz: "biz"},
+          %{"Mxxxx" => 1},
           [
             %{
-              "public_key" => "Mxxxx",
-              "instance_id" => "42"
-            }
-          ],
-          [
-            %{
-              "contract_id" => "wasmcloud:test",
-              "instance_id" => "43",
               "link_name" => "default",
               "public_key" => "Vxxxx"
             }

--- a/test/observed/hosts_test.exs
+++ b/test/observed/hosts_test.exs
@@ -319,7 +319,7 @@ defmodule LatticeObserverTest.Observed.HostsTest do
 
       assert l.providers == %{
                {"Vxxxxx", "default"} => %LatticeObserver.Observed.Provider{
-                 contract_id: "n/a",
+                 contract_id: "wasmcloud:test",
                  id: "Vxxxxx",
                  instances: [
                    %LatticeObserver.Observed.Instance{

--- a/test/observed/hosts_test.exs
+++ b/test/observed/hosts_test.exs
@@ -135,6 +135,113 @@ defmodule LatticeObserverTest.Observed.HostsTest do
     #   "uptime_seconds": 92,
     #   "version": "0.60.0"
 
+    test "Propertly records LEGACY host heartbeat" do
+      hb = CloudEvents.host_heartbeat_old(@test_host, %{foo: "bar", baz: "biz"})
+      stamp = EventProcessor.timestamp_from_iso8601(hb.time)
+      l = Lattice.apply_event(Lattice.new(), hb)
+
+      assert l.hosts[@test_host].labels == %{baz: "biz", foo: "bar"}
+      assert l.hosts[@test_host].status == :healthy
+      assert l.hosts[@test_host].last_seen == stamp
+
+      hb2 = CloudEvents.host_heartbeat_old(@test_host, %{foo: "bar", baz: "biz"})
+      stamp2 = EventProcessor.timestamp_from_iso8601(hb2.time)
+      l = Lattice.apply_event(l, hb2)
+
+      assert l.hosts[@test_host].labels == %{baz: "biz", foo: "bar"}
+      assert l.hosts[@test_host].status == :healthy
+      assert l.hosts[@test_host].last_seen == stamp2
+
+      hb3 =
+        CloudEvents.host_heartbeat(
+          @test_host,
+          %{foo: "bar"},
+          [
+            %{
+              "public_key" => "Mxxxx",
+              "instance_id" => "iid1"
+            },
+            %{
+              "public_key" => "Mxxxy",
+              "instance_id" => "iid2"
+            }
+          ],
+          [
+            %{
+              "public_key" => "Vxxxxx",
+              "instance_id" => "iid3",
+              "contract_id" => "wasmcloud:test",
+              "link_name" => "default"
+            }
+          ]
+        )
+
+      # Scenario: heartbeat contains fewer actors than the previous one, yet
+      # the lattice did not receive an actor stopped event.
+      hb4 =
+        CloudEvents.host_heartbeat(
+          @test_host,
+          %{foo: "bar"},
+          [
+            %{
+              "public_key" => "Mxxxx",
+              "instance_id" => "iid1"
+            }
+          ],
+          [
+            %{
+              "public_key" => "Vxxxxx",
+              "instance_id" => "iid3",
+              "contract_id" => "wasmcloud:test",
+              "link_name" => "default"
+            }
+          ]
+        )
+
+      l = Lattice.apply_event(Lattice.new(), hb3) |> Lattice.apply_event(hb4)
+
+      # The Mxxxy actor isn't here because of authoritative heartbeats
+      assert l.actors == %{
+               "Mxxxx" => %LatticeObserver.Observed.Actor{
+                 call_alias: "",
+                 capabilities: [],
+                 id: "Mxxxx",
+                 instances: [
+                   %LatticeObserver.Observed.Instance{
+                     host_id: "Nxxx",
+                     id: "iid1",
+                     revision: 0,
+                     spec_id: "",
+                     version: ""
+                   }
+                 ],
+                 issuer: "",
+                 name: "unavailable",
+                 tags: ""
+               }
+             }
+
+      assert l.providers == %{
+               {"Vxxxxx", "default"} => %LatticeObserver.Observed.Provider{
+                 contract_id: "wasmcloud:test",
+                 id: "Vxxxxx",
+                 instances: [
+                   %LatticeObserver.Observed.Instance{
+                     host_id: "Nxxx",
+                     id: "iid3",
+                     revision: 0,
+                     spec_id: "",
+                     version: ""
+                   }
+                 ],
+                 issuer: "",
+                 link_name: "default",
+                 name: "unavailable",
+                 tags: ""
+               }
+             }
+    end
+
     test "Properly records host heartbeat" do
       hb = CloudEvents.host_heartbeat(@test_host, %{foo: "bar", baz: "biz"})
       stamp = EventProcessor.timestamp_from_iso8601(hb.time)

--- a/test/observed/hosts_test.exs
+++ b/test/observed/hosts_test.exs
@@ -115,6 +115,26 @@ defmodule LatticeObserverTest.Observed.HostsTest do
                Lattice.new()
     end
 
+    # updated heartbeat shape
+    #  "actors": {
+    #   "MB2ZQB6ROOMAYBO4ZCTFYWN7YIVBWA3MTKZYAQKJMTIHE2ELLRW2E3ZW": 10
+    #   },
+    #   "friendly_name": "wandering-meadow-5880",
+    #   "labels": {
+    #     "hostcore.arch": "aarch64",
+    #     "hostcore.os": "macos",
+    #     "hostcore.osfamily": "unix"
+    #   },
+    #   "providers": [
+    #     {
+    #       "link_name": "default",
+    #       "public_key": "VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M"
+    #     }
+    #   ],
+    #   "uptime_human": "1 minute, 32 seconds",
+    #   "uptime_seconds": 92,
+    #   "version": "0.60.0"
+
     test "Properly records host heartbeat" do
       hb = CloudEvents.host_heartbeat(@test_host, %{foo: "bar", baz: "biz"})
       stamp = EventProcessor.timestamp_from_iso8601(hb.time)
@@ -136,20 +156,13 @@ defmodule LatticeObserverTest.Observed.HostsTest do
         CloudEvents.host_heartbeat(
           @test_host,
           %{foo: "bar"},
-          [
-            %{
-              "public_key" => "Mxxxx",
-              "instance_id" => "iid1"
-            },
-            %{
-              "public_key" => "Mxxxy",
-              "instance_id" => "iid2"
-            }
-          ],
+          %{
+            "Mxxxx" => 1,
+            "Mxxxy" => 2
+          },
           [
             %{
               "public_key" => "Vxxxxx",
-              "instance_id" => "iid3",
               "contract_id" => "wasmcloud:test",
               "link_name" => "default"
             }
@@ -162,16 +175,12 @@ defmodule LatticeObserverTest.Observed.HostsTest do
         CloudEvents.host_heartbeat(
           @test_host,
           %{foo: "bar"},
-          [
-            %{
-              "public_key" => "Mxxxx",
-              "instance_id" => "iid1"
-            }
-          ],
+          %{
+            "Mxxxx" => 1
+          },
           [
             %{
               "public_key" => "Vxxxxx",
-              "instance_id" => "iid3",
               "contract_id" => "wasmcloud:test",
               "link_name" => "default"
             }
@@ -189,7 +198,7 @@ defmodule LatticeObserverTest.Observed.HostsTest do
                  instances: [
                    %LatticeObserver.Observed.Instance{
                      host_id: "Nxxx",
-                     id: "iid1",
+                     id: "n/a",
                      revision: 0,
                      spec_id: "",
                      version: ""
@@ -203,12 +212,12 @@ defmodule LatticeObserverTest.Observed.HostsTest do
 
       assert l.providers == %{
                {"Vxxxxx", "default"} => %LatticeObserver.Observed.Provider{
-                 contract_id: "wasmcloud:test",
+                 contract_id: "n/a",
                  id: "Vxxxxx",
                  instances: [
                    %LatticeObserver.Observed.Instance{
                      host_id: "Nxxx",
-                     id: "iid3",
+                     id: "n/a",
                      revision: 0,
                      spec_id: "",
                      version: ""

--- a/test/support/cloud_events.ex
+++ b/test/support/cloud_events.ex
@@ -103,7 +103,7 @@ defmodule TestSupport.CloudEvents do
     |> LatticeObserver.CloudEvent.new("provider_stopped", host)
   end
 
-  def host_heartbeat(host, labels, actors \\ [], providers \\ []) do
+  def host_heartbeat(host, labels, actors \\ %{}, providers \\ []) do
     %{
       "actors" => actors,
       "providers" => providers,

--- a/test/support/cloud_events.ex
+++ b/test/support/cloud_events.ex
@@ -152,4 +152,13 @@ defmodule TestSupport.CloudEvents do
     }
     |> LatticeObserver.CloudEvent.new("invocation_failed", host)
   end
+
+  def host_heartbeat_old(host, labels, actors \\ [], providers \\ []) do
+    %{
+      "actors" => actors,
+      "providers" => providers,
+      "labels" => labels
+    }
+    |> LatticeObserver.CloudEvent.new("host_heartbeat", host)
+  end
 end


### PR DESCRIPTION
Tested via updated unit tests.

When receiving heartbeats from 0.60 RC7 and later, replaces contract ID with `n/a` , and instance IDs with `n/a` because that information is no longer emitted by the host during heartbeats.

Heartbeats generated by older hosts are handled just fine.