### PR TITLE
Removes dependence on instance ID for all monitoring logic

### DIFF
--- a/lib/lattice_observer/observed/lattice.ex
+++ b/lib/lattice_observer/observed/lattice.ex
@@ -311,8 +311,7 @@ defmodule LatticeObserver.Observed.Lattice do
           data:
             %{
               "link_name" => link_name,
-              "public_key" => pk,
-              "instance_id" => instance_id
+              "public_key" => pk
             } = d,
           datacontenttype: "application/json",
           source: source_host,
@@ -322,7 +321,7 @@ defmodule LatticeObserver.Observed.Lattice do
       ) do
     annotations = Map.get(d, "annotations", %{})
     spec = Map.get(annotations, @annotation_app_spec, "")
-    EventProcessor.remove_provider_instance(l, source_host, pk, link_name, instance_id, spec)
+    EventProcessor.remove_provider_instance(l, source_host, pk, link_name, spec)
   end
 
   def apply_event(

--- a/test/observed/actors_test.exs
+++ b/test/observed/actors_test.exs
@@ -13,8 +13,9 @@ defmodule LatticeObserverTest.Observed.ActorsTest do
       l = Lattice.new()
       l = Lattice.apply_event(l, start)
       stamp1 = EventProcessor.timestamp_from_iso8601(start.time)
+
       # ensure idempotence
-      l = Lattice.apply_event(l, start)
+      # l = Lattice.apply_event(l, start)
 
       assert l == %Lattice{
                Lattice.new()

--- a/test/observed/actors_test.exs
+++ b/test/observed/actors_test.exs
@@ -1,10 +1,9 @@
 defmodule LatticeObserverTest.Observed.ActorsTest do
   use ExUnit.Case
-  alias LatticeObserver.Observed.{Lattice, Instance, Actor, EventProcessor}
+  alias LatticeObserver.Observed.{Lattice, Instance, Actor}
   alias TestSupport.CloudEvents
 
   @test_spec "testapp"
-  @test_spec_2 "othertestapp"
   @test_host "Nxxx"
 
   describe "Observed Lattice Monitors Actor Events" do
@@ -12,10 +11,6 @@ defmodule LatticeObserverTest.Observed.ActorsTest do
       start = CloudEvents.actor_started("Mxxx", "abc123", @test_spec, @test_host)
       l = Lattice.new()
       l = Lattice.apply_event(l, start)
-      stamp1 = EventProcessor.timestamp_from_iso8601(start.time)
-
-      # ensure idempotence
-      # l = Lattice.apply_event(l, start)
 
       assert l == %Lattice{
                Lattice.new()
@@ -50,9 +45,7 @@ defmodule LatticeObserverTest.Observed.ActorsTest do
                      version: "1.0"
                    }
                  },
-                 instance_tracking: %{
-                   "abc123" => stamp1
-                 }
+                 instance_tracking: %{}
              }
 
       stop = CloudEvents.actor_stopped("Mxxx", "abc123", @test_spec, @test_host)
@@ -74,107 +67,6 @@ defmodule LatticeObserverTest.Observed.ActorsTest do
                      tags: "",
                      version: "1.0"
                    }
-                 }
-             }
-    end
-
-    test "Stores the same actor belonging to multiple specs" do
-      start = CloudEvents.actor_started("Mxxx", "abc123", @test_spec, @test_host)
-      l = Lattice.new()
-      l = Lattice.apply_event(l, start)
-      start2 = CloudEvents.actor_started("Mxxx", "abc345", @test_spec_2, @test_host)
-      l = Lattice.apply_event(l, start2)
-      stamp1 = EventProcessor.timestamp_from_iso8601(start.time)
-      stamp2 = EventProcessor.timestamp_from_iso8601(start2.time)
-
-      assert l == %Lattice{
-               Lattice.new()
-               | actors: %{
-                   "Mxxx" => %Actor{
-                     call_alias: "",
-                     capabilities: ["test", "test2"],
-                     id: "Mxxx",
-                     instances: [
-                       %Instance{
-                         host_id: "Nxxx",
-                         id: "abc345",
-                         revision: 0,
-                         spec_id: "othertestapp",
-                         version: "1.0"
-                       },
-                       %Instance{
-                         host_id: "Nxxx",
-                         id: "abc123",
-                         revision: 0,
-                         spec_id: "testapp",
-                         version: "1.0"
-                       }
-                     ],
-                     issuer: "ATESTxxx",
-                     name: "Test Actor",
-                     tags: ""
-                   }
-                 },
-                 claims: %{
-                   "Mxxx" => %LatticeObserver.Observed.Claims{
-                     call_alias: "",
-                     caps: "test,test2",
-                     iss: "ATESTxxx",
-                     name: "Test Actor",
-                     rev: 0,
-                     sub: "Mxxx",
-                     tags: "",
-                     version: "1.0"
-                   }
-                 },
-                 instance_tracking: %{
-                   "abc123" => stamp1,
-                   "abc345" => stamp2
-                 }
-             }
-
-      assert Lattice.actors_in_appspec(l, "testapp") == [
-               %{actor_id: "Mxxx", host_id: "Nxxx", instance_id: "abc123"}
-             ]
-
-      stop = CloudEvents.actor_stopped("Mxxx", "abc123", @test_spec, @test_host)
-      l = Lattice.apply_event(l, stop)
-
-      assert l == %LatticeObserver.Observed.Lattice{
-               Lattice.new()
-               | actors: %{
-                   "Mxxx" => %Actor{
-                     call_alias: "",
-                     capabilities: ["test", "test2"],
-                     id: "Mxxx",
-                     instances: [
-                       %Instance{
-                         host_id: "Nxxx",
-                         id: "abc345",
-                         revision: 0,
-                         spec_id: "othertestapp",
-                         version: "1.0"
-                       }
-                     ],
-                     issuer: "ATESTxxx",
-                     name: "Test Actor",
-                     tags: ""
-                   }
-                 },
-                 claims: %{
-                   "Mxxx" => %LatticeObserver.Observed.Claims{
-                     call_alias: "",
-                     caps: "test,test2",
-                     iss: "ATESTxxx",
-                     name: "Test Actor",
-                     rev: 0,
-                     sub: "Mxxx",
-                     tags: "",
-                     version: "1.0"
-                   }
-                 },
-                 instance_tracking: %{
-                   "abc345" => stamp2
                  }
              }
     end

--- a/test/observed/claims_test.exs
+++ b/test/observed/claims_test.exs
@@ -1,6 +1,6 @@
 defmodule LatticeObserverTest.Observed.ClaimsTest do
   use ExUnit.Case
-  alias LatticeObserver.Observed.{Lattice, Instance, Claims}
+  alias LatticeObserver.Observed.{Lattice, Claims}
   alias TestSupport.CloudEvents
 
   describe "Claims cache works appropriately" do

--- a/test/observed/hosts_test.exs
+++ b/test/observed/hosts_test.exs
@@ -48,7 +48,6 @@ defmodule LatticeObserverTest.Observed.HostsTest do
 
       assert Map.keys(l.hosts) == ["Nxxxy"]
       assert (l.hosts |> Map.values() |> List.first()).friendly_name == "yellow-cat-6"
-      assert Map.keys(l.instance_tracking) == ["abc123", "abc456", "abc789"]
       assert l.providers == %{}
       assert l.actors == %{}
     end
@@ -83,7 +82,6 @@ defmodule LatticeObserverTest.Observed.HostsTest do
 
       assert Map.keys(l.hosts) == ["Nxxx"]
       assert (l.hosts |> Map.values() |> List.first()).friendly_name == "orange-button-5"
-      assert Map.keys(l.instance_tracking) == ["abc123", "abc456", "abc789"]
 
       # Host is killed forcefully and starts again using the same seed private key
       l =

--- a/test/observed/providers_test.exs
+++ b/test/observed/providers_test.exs
@@ -24,8 +24,6 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
       l = Lattice.new()
       l = Lattice.apply_event(l, start)
       stamp1 = EventProcessor.timestamp_from_iso8601(start.time)
-      # ensure idempotence
-      l = Lattice.apply_event(l, start)
 
       orig_desired = %Lattice{
         Lattice.new()

--- a/test/observed/providers_test.exs
+++ b/test/observed/providers_test.exs
@@ -6,6 +6,7 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
   @test_spec "testapp"
   @test_spec_2 "othertestapp"
   @test_host "Nxxx"
+  @test_host2 "Nxxy"
   @test_contract "wasmcloud:test"
 
   describe "Observed Lattice Monitors Provider Events" do
@@ -15,7 +16,7 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
           "Vxxx",
           @test_contract,
           "default",
-          "abc123",
+          "n/a",
           @test_spec,
           @test_host
         )
@@ -29,7 +30,7 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
       orig_desired = %Lattice{
         Lattice.new()
         | instance_tracking: %{
-            "abc123" => stamp1
+            "n/a" => stamp1
           },
           claims: %{
             "Vxxx" => %LatticeObserver.Observed.Claims{
@@ -50,7 +51,7 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
               instances: [
                 %Instance{
                   host_id: "Nxxx",
-                  id: "abc123",
+                  id: "n/a",
                   revision: 2,
                   spec_id: "testapp",
                   version: "1.0"
@@ -71,7 +72,7 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
                  %{
                    contract_id: "wasmcloud:test",
                    host_id: "Nxxx",
-                   instance_id: "abc123",
+                   instance_id: "n/a",
                    link_name: "default",
                    provider_id: "Vxxx"
                  }
@@ -89,9 +90,11 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
 
       l = Lattice.apply_event(l, stop)
 
+      # Note that the instance tracking field is now deprecated/useless
       desired = %Lattice{
         Lattice.new()
         | providers: %{},
+          instance_tracking: %{"n/a" => stamp1},
           claims: %{
             "Vxxx" => %LatticeObserver.Observed.Claims{
               call_alias: nil,
@@ -119,20 +122,19 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
           "Vxxx",
           @test_contract,
           "default",
-          "abc123",
+          "n/a",
           @test_spec,
           @test_host
         )
 
-      stamp = EventProcessor.timestamp_from_iso8601(start.time)
       l = Lattice.apply_event(Lattice.new(), start)
 
       start2 =
         CloudEvents.provider_started(
           "Vxxx",
           @test_contract,
-          "default",
-          "abc456",
+          "not-so-default",
+          "n/a",
           @test_spec,
           @test_host
         )
@@ -142,7 +144,7 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
 
       assert l == %Lattice{
                Lattice.new()
-               | instance_tracking: %{"abc123" => stamp, "abc456" => stamp2},
+               | instance_tracking: %{"n/a" => stamp2},
                  providers: %{
                    {"Vxxx", "default"} => %LatticeObserver.Observed.Provider{
                      contract_id: "wasmcloud:test",
@@ -150,14 +152,7 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
                      instances: [
                        %LatticeObserver.Observed.Instance{
                          host_id: "Nxxx",
-                         id: "abc456",
-                         revision: 2,
-                         spec_id: "testapp",
-                         version: "1.0"
-                       },
-                       %LatticeObserver.Observed.Instance{
-                         host_id: "Nxxx",
-                         id: "abc123",
+                         id: "n/a",
                          revision: 2,
                          spec_id: "testapp",
                          version: "1.0"
@@ -165,6 +160,23 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
                      ],
                      issuer: "ATESTxxx",
                      link_name: "default",
+                     name: "test provider",
+                     tags: "a,b"
+                   },
+                   {"Vxxx", "not-so-default"} => %LatticeObserver.Observed.Provider{
+                     contract_id: "wasmcloud:test",
+                     id: "Vxxx",
+                     instances: [
+                       %LatticeObserver.Observed.Instance{
+                         host_id: "Nxxx",
+                         id: "n/a",
+                         revision: 2,
+                         spec_id: "testapp",
+                         version: "1.0"
+                       }
+                     ],
+                     issuer: "ATESTxxx",
+                     link_name: "not-so-default",
                      name: "test provider",
                      tags: "a,b"
                    }
@@ -189,9 +201,9 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
           "Vxxx",
           @test_contract,
           "default",
-          "abc789",
+          "n/a",
           @test_spec_2,
-          @test_host
+          @test_host2
         )
 
       stamp3 = EventProcessor.timestamp_from_iso8601(start3.time)
@@ -201,9 +213,7 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
       assert l == %Lattice{
                Lattice.new()
                | instance_tracking: %{
-                   "abc123" => stamp,
-                   "abc456" => stamp2,
-                   "abc789" => stamp3
+                   "n/a" => stamp3
                  },
                  providers: %{
                    {"Vxxx", "default"} => %Provider{
@@ -214,28 +224,38 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
                      id: "Vxxx",
                      instances: [
                        %Instance{
-                         host_id: "Nxxx",
-                         id: "abc789",
+                         host_id: "Nxxy",
+                         id: "n/a",
                          spec_id: "othertestapp",
                          revision: 2,
                          version: "1.0"
                        },
                        %Instance{
                          host_id: "Nxxx",
-                         id: "abc456",
-                         spec_id: "testapp",
-                         revision: 2,
-                         version: "1.0"
-                       },
-                       %Instance{
-                         host_id: "Nxxx",
-                         id: "abc123",
+                         id: "n/a",
                          spec_id: "testapp",
                          revision: 2,
                          version: "1.0"
                        }
                      ],
                      link_name: "default"
+                   },
+                   {"Vxxx", "not-so-default"} => %LatticeObserver.Observed.Provider{
+                     contract_id: "wasmcloud:test",
+                     id: "Vxxx",
+                     instances: [
+                       %LatticeObserver.Observed.Instance{
+                         host_id: "Nxxx",
+                         id: "n/a",
+                         revision: 2,
+                         spec_id: "testapp",
+                         version: "1.0"
+                       }
+                     ],
+                     issuer: "ATESTxxx",
+                     link_name: "not-so-default",
+                     name: "test provider",
+                     tags: "a,b"
                    }
                  },
                  claims: %{


### PR DESCRIPTION
Since instance ID will always be "n/a" on the new 0.60 heartbeats, this removes reliance on instance IDs for building the observed model.