### PR TITLE
enable dialyzer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,10 @@ jobs:
         if: ${{ !startswith(matrix.os, 'windows') }} # Windows gets angry about carriage returns
         run: mix format --check-formatted
 
+      - name: Run dialyzer
+        working-directory: ${{env.working-directory}}
+        run: mix dialyzer
+
       - name: Run NATS for tests
         uses: wasmcloud/common-actions/run-nats@main
         if: ${{ startswith(matrix.os, 'ubuntu') }} # Run on Ubuntu only as a temporary workaround to dependencies that aren't present on windows/mac runners

--- a/lib/lattice_observer/observed/actor.ex
+++ b/lib/lattice_observer/observed/actor.ex
@@ -9,12 +9,12 @@ defmodule LatticeObserver.Observed.Actor do
   An actor observed through event receipt within the lattice.
   """
   @type t :: %Actor{
-          id: String.t(),
-          name: String.t(),
-          capabilities: [String.t()],
-          issuer: String.t(),
-          tags: String.t(),
-          call_alias: String.t(),
+          id: binary(),
+          name: binary(),
+          capabilities: [binary()],
+          issuer: binary(),
+          tags: binary(),
+          call_alias: binary(),
           instances: [Instance.t()]
         }
 

--- a/lib/lattice_observer/observed/claims.ex
+++ b/lib/lattice_observer/observed/claims.ex
@@ -16,16 +16,16 @@ defmodule LatticeObserver.Observed.Claims do
   ]
 
   @type t :: %Claims{
-          sub: String.t(),
-          call_alias: String.t(),
-          iss: String.t(),
-          name: String.t(),
+          sub: binary(),
+          call_alias: binary(),
+          iss: binary(),
+          name: binary(),
           # Comma-delimited list
-          caps: String.t(),
-          rev: String.t(),
+          caps: binary(),
+          rev: binary(),
           # Comma-delimited list
-          tags: String.t(),
-          version: String.t()
+          tags: binary(),
+          version: binary()
         }
 
   # Apply a capability provider's claims

--- a/lib/lattice_observer/observed/decay.ex
+++ b/lib/lattice_observer/observed/decay.ex
@@ -28,14 +28,14 @@ defmodule LatticeObserver.Observed.Decay do
 
   # Returns a tuple with two elements, the first is a list of hosts that have fully
   # decayed and are removed from the lattice, the second is the new list of hosts
-  @spec partition_hosts(Lattice.hostmap(), DateTime.t(), Integer.t()) :: {list(), list()}
+  @spec partition_hosts(Lattice.hostmap(), DateTime.t(), integer()) :: {list(), list()}
   defp partition_hosts(hosts, event_time, decay_rate) do
     hosts
     |> Enum.map(fn {hk, host} -> {hk, age_host(host, event_time, decay_rate)} end)
     |> Enum.split_with(fn {_hk, host} -> host.status == :remove end)
   end
 
-  @spec age_host(Host.t(), DateTime.t(), Integer.t()) :: Host.t()
+  @spec age_host(Host.t(), DateTime.t(), integer()) :: Host.t()
   defp age_host(host, event_time, decay_rate) do
     gapfactor = div(DateTime.diff(event_time, host.last_seen), decay_rate)
 

--- a/lib/lattice_observer/observed/event_processor.ex
+++ b/lib/lattice_observer/observed/event_processor.ex
@@ -376,7 +376,7 @@ defmodule LatticeObserver.Observed.EventProcessor do
     }
   end
 
-  def remove_actor_instance(l = %Lattice{}, host_id, pk, instance_id, _spec) do
+  def remove_actor_instance(l = %Lattice{}, host_id, pk, _spec) do
     actor = l.actors[pk]
 
     if actor != nil do

--- a/lib/lattice_observer/observed/host.ex
+++ b/lib/lattice_observer/observed/host.ex
@@ -8,11 +8,11 @@ defmodule LatticeObserver.Observed.Host do
   Represents a host observed through heartbeat and start events within a lattice
   """
   @type t :: %Host{
-          id: String.t(),
-          labels: Map.t(),
+          id: binary(),
+          labels: map(),
           status: LatticeObserver.Observed.Lattice.entitystatus(),
-          last_seen: Datetime.t(),
-          first_seen: Datetime.t(),
+          last_seen: DateTime.t(),
+          first_seen: DateTime.t(),
           friendly_name: String.t()
         }
 end

--- a/lib/lattice_observer/observed/instance.ex
+++ b/lib/lattice_observer/observed/instance.ex
@@ -11,10 +11,10 @@ defmodule LatticeObserver.Observed.Instance do
   both have instances while link definitions do not.
   """
   @type t :: %Instance{
-          id: String.t(),
-          host_id: String.t(),
-          spec_id: String.t(),
-          version: String.t(),
-          revision: Integer.t()
+          id: binary(),
+          host_id: binary(),
+          spec_id: binary(),
+          version: binary(),
+          revision: integer()
         }
 end

--- a/lib/lattice_observer/observed/invocation.ex
+++ b/lib/lattice_observer/observed/invocation.ex
@@ -2,17 +2,14 @@ defmodule LatticeObserver.Observed.Invocation do
   alias LatticeObserver.Observed.Lattice
   alias __MODULE__.Entity
 
-  @type invocationlog_key :: {from :: Entity.t(), to :: Entity.t(), operation :: String.t()}
-  @type invocationlog_map :: %{required(invocationlog_key()) => InvocationLog.t()}
-
   defmodule InvocationLog do
     @type t :: %InvocationLog{
             from: Entity.t(),
             to: Entity.t(),
-            operation: String.t(),
-            total_bytes: Integer.t(),
-            fail_count: Integer.t(),
-            success_count: Integer.t()
+            operation: binary(),
+            total_bytes: integer(),
+            fail_count: integer(),
+            success_count: integer()
           }
 
     defstruct [:from, :to, :operation, :total_bytes, :fail_count, :success_count]
@@ -31,9 +28,9 @@ defmodule LatticeObserver.Observed.Invocation do
 
   defmodule Entity do
     @type t :: %Entity{
-            public_key: String.t(),
-            link_name: String.t() | nil,
-            contract_id: String.t() | nil
+            public_key: binary(),
+            link_name: binary() | nil,
+            contract_id: binary() | nil
           }
     defstruct [:public_key, :link_name, :contract_id]
 
@@ -56,12 +53,15 @@ defmodule LatticeObserver.Observed.Invocation do
     end
   end
 
+  @type invocationlog_key :: {from :: Entity.t(), to :: Entity.t(), operation :: binary()}
+  @type invocationlog_map :: %{required(invocationlog_key()) => InvocationLog.t()}
+
   @spec record_invocation_success(
           Lattice.t(),
-          source :: Map.t(),
-          dest :: Map.t(),
-          operation :: String.t(),
-          Integer.t()
+          source :: map(),
+          dest :: map(),
+          operation :: binary(),
+          integer()
         ) ::
           Lattice.t()
   def record_invocation_success(l = %Lattice{}, source, dest, operation, bytes) do
@@ -82,10 +82,10 @@ defmodule LatticeObserver.Observed.Invocation do
 
   @spec record_invocation_failed(
           Lattice.t(),
-          source :: Map.t(),
-          dest :: Map.t(),
-          operation :: String.t(),
-          Integer.t()
+          source :: map(),
+          dest :: map(),
+          operation :: binary(),
+          integer()
         ) ::
           Lattice.t()
   def record_invocation_failed(l = %Lattice{}, source, dest, operation, bytes) do

--- a/lib/lattice_observer/observed/link_definition.ex
+++ b/lib/lattice_observer/observed/link_definition.ex
@@ -12,10 +12,10 @@ defmodule LatticeObserver.Observed.LinkDefinition do
   Link definitions are uniquely identified by the actor ID, provider ID, and link name.
   """
   @type t :: %LinkDefinition{
-          actor_id: String.t(),
-          provider_id: String.t(),
-          contract_id: String.t(),
-          link_name: String.t(),
-          values: Map.t()
+          actor_id: binary(),
+          provider_id: binary(),
+          contract_id: binary(),
+          link_name: binary(),
+          values: map()
         }
 end

--- a/lib/lattice_observer/observed/provider.ex
+++ b/lib/lattice_observer/observed/provider.ex
@@ -11,12 +11,12 @@ defmodule LatticeObserver.Observed.Provider do
   are tracked in the same way as actor instances.
   """
   @type t :: %Provider{
-          id: String.t(),
-          name: String.t(),
-          issuer: String.t(),
-          contract_id: String.t(),
-          tags: String.t(),
-          link_name: String.t(),
+          id: binary(),
+          name: binary(),
+          issuer: binary(),
+          contract_id: binary(),
+          tags: binary(),
+          link_name: binary(),
           instances: [Instance.t()]
         }
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,11 +4,12 @@ defmodule LatticeObserver.MixProject do
   def project do
     [
       app: :lattice_observer,
-      version: "0.3.0",
+      version: "0.4.0",
       elixir: "~> 1.12",
       elixirc_paths: compiler_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      dialyzer: [plt_add_deps: :apps_direct]
     ]
   end
 
@@ -24,6 +25,7 @@ defmodule LatticeObserver.MixProject do
   defp deps do
     [
       {:cloudevents, "~> 0.6.1"},
+      {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:uuid, "~> 1.1"},
       {:jason, "~> 1.2"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
 %{
   "cloudevents": {:hex, :cloudevents, "0.6.1", "d3f467a615c00712cf3c9632f6d131695fd3e1d29c10477d2d2fbbec06350522", [:mix], [{:avrora, "~> 0.21", [hex: :avrora, repo: "hexpm", optional: true]}, {:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: false]}, {:typed_struct, "~> 0.3.0", [hex: :typed_struct, repo: "hexpm", optional: false]}], "hexpm", "f0055549bc651bd6702347328dd5824d3f08fbf308d2c7212252e34e345bcb9c"},
+  "dialyxir": {:hex, :dialyxir, "1.2.0", "58344b3e87c2e7095304c81a9ae65cb68b613e28340690dfe1a5597fd08dec37", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "61072136427a851674cab81762be4dbeae7679f85b1272b6d25c3a839aff8463"},
+  "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
   "jason": {:hex, :jason, "1.3.0", "fa6b82a934feb176263ad2df0dbd91bf633d4a46ebfdffea0c8ae82953714946", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "53fc1f51255390e0ec7e50f9cb41e751c260d065dcba2bf0d08dc51a4002c2ac"},
   "typed_struct": {:hex, :typed_struct, "0.3.0", "939789e3c1dca39d7170c87f729127469d1315dcf99fee8e152bb774b17e7ff7", [:mix], [], "hexpm", "c50bd5c3a61fe4e198a8504f939be3d3c85903b382bde4865579bc23111d1b6d"},
   "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm", "c790593b4c3b601f5dc2378baae7efaf5b3d73c4c6456ba85759905be792f2ac"},

--- a/test/observed/providers_test.exs
+++ b/test/observed/providers_test.exs
@@ -32,8 +32,8 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
           },
           claims: %{
             "Vxxx" => %LatticeObserver.Observed.Claims{
-              call_alias: nil,
-              caps: nil,
+              call_alias: "",
+              caps: "",
               iss: "ATESTxxx",
               name: "test provider",
               rev: 2,
@@ -95,8 +95,8 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
           instance_tracking: %{"n/a" => stamp1},
           claims: %{
             "Vxxx" => %LatticeObserver.Observed.Claims{
-              call_alias: nil,
-              caps: nil,
+              call_alias: "",
+              caps: "",
               iss: "ATESTxxx",
               name: "test provider",
               rev: 2,
@@ -181,8 +181,8 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
                  },
                  claims: %{
                    "Vxxx" => %LatticeObserver.Observed.Claims{
-                     call_alias: nil,
-                     caps: nil,
+                     call_alias: "",
+                     caps: "",
                      iss: "ATESTxxx",
                      name: "test provider",
                      rev: 2,
@@ -258,8 +258,8 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
                  },
                  claims: %{
                    "Vxxx" => %LatticeObserver.Observed.Claims{
-                     call_alias: nil,
-                     caps: nil,
+                     call_alias: "",
+                     caps: "",
                      iss: "ATESTxxx",
                      name: "test provider",
                      rev: 2,


### PR DESCRIPTION
This PR enables dialyzer for the lattice-observer. Here's what changed:
- fixed a few typos, like `Datetime` (instead of `DateTime`) and `InvocationLog` (instead of `Invocation.Log`)
- removed `instance_id` from `remove_actor_instance` since it wasn't used
- added checks for `call_alias` and `caps` when applying claims for a provider. These aren't part of the event from the host, but the `Claims` type here requires the fields

Signed-off-by: Connor Smith <connor.smith.256@gmail.com>