### PR TITLE
Add uptime_seconds and version to Host

### DIFF
--- a/lib/lattice_observer/observed/event_processor.ex
+++ b/lib/lattice_observer/observed/event_processor.ex
@@ -215,6 +215,8 @@ defmodule LatticeObserver.Observed.EventProcessor do
     friendly_name = Map.get(data, "friendly_name", "")
     annotations = Map.get(data, "annotations", %{})
     spec = Map.get(annotations, @annotation_app_spec, "")
+    uptime_seconds = Map.get(data, "uptime_seconds", 0)
+    version = Map.get(data, "version", "v0.0.0")
 
     # Heartbeats are now considered authoritative, so the previously stored
     # actor and provider list are wiped prior to recording the heartbeat, but the
@@ -245,7 +247,7 @@ defmodule LatticeObserver.Observed.EventProcessor do
       }
       |> strip_instanceless_entities()
 
-    l = record_host(l, source_host, labels, stamp, friendly_name)
+    l = record_host(l, source_host, labels, stamp, friendly_name, uptime_seconds, version)
 
     # legacy heartbeat has a list for the actors field...
     # default to "new format" if this field is missing
@@ -320,13 +322,23 @@ defmodule LatticeObserver.Observed.EventProcessor do
     end)
   end
 
-  def record_host(l = %Lattice{}, source_host, labels, stamp, friendly_name \\ "") do
+  def record_host(
+        l = %Lattice{},
+        source_host,
+        labels,
+        stamp,
+        friendly_name,
+        uptime_seconds,
+        version
+      ) do
     host =
       Map.get(l.hosts, source_host, %Host{
         id: source_host,
         labels: labels,
         first_seen: timestamp_from_iso8601(stamp),
-        friendly_name: friendly_name
+        friendly_name: friendly_name,
+        uptime_seconds: uptime_seconds,
+        version: version
       })
 
     # Every time we see a host, we set the last seen stamp

--- a/lib/lattice_observer/observed/event_processor.ex
+++ b/lib/lattice_observer/observed/event_processor.ex
@@ -349,6 +349,7 @@ defmodule LatticeObserver.Observed.EventProcessor do
         host,
         %{
           last_seen: timestamp_from_iso8601(stamp),
+          uptime_seconds: uptime_seconds,
           status: :healthy
         }
       )

--- a/lib/lattice_observer/observed/host.ex
+++ b/lib/lattice_observer/observed/host.ex
@@ -2,7 +2,16 @@ defmodule LatticeObserver.Observed.Host do
   alias __MODULE__
 
   @enforce_keys [:id, :labels]
-  defstruct [:id, :labels, :status, :last_seen, :first_seen, :friendly_name]
+  defstruct [
+    :id,
+    :labels,
+    :status,
+    :last_seen,
+    :first_seen,
+    :friendly_name,
+    :uptime_seconds,
+    :version
+  ]
 
   @typedoc """
   Represents a host observed through heartbeat and start events within a lattice
@@ -13,6 +22,8 @@ defmodule LatticeObserver.Observed.Host do
           status: LatticeObserver.Observed.Lattice.entitystatus(),
           last_seen: DateTime.t(),
           first_seen: DateTime.t(),
-          friendly_name: String.t()
+          friendly_name: binary(),
+          uptime_seconds: non_neg_integer(),
+          version: binary()
         }
 end

--- a/lib/lattice_observer/observed/lattice.ex
+++ b/lib/lattice_observer/observed/lattice.ex
@@ -144,6 +144,8 @@ defmodule LatticeObserver.Observed.Lattice do
       ) do
     labels = Map.get(data, "labels", %{})
     friendly_name = Map.get(data, "friendly_name", "")
+    uptime_seconds = Map.get(data, "uptime_seconds", 0)
+    version = Map.get(data, "version", "v0.0.0")
     # First, remove any leftover host artifacts from the lattice,
     # then record the host started event.
     #
@@ -151,7 +153,14 @@ defmodule LatticeObserver.Observed.Lattice do
     # circumstances (e.g. getting kill -9'ed) and retains the same host key properly
     # clears the cache.
     EventProcessor.remove_host(l, source_host)
-    |> EventProcessor.record_host(source_host, labels, stamp, friendly_name)
+    |> EventProcessor.record_host(
+      source_host,
+      labels,
+      stamp,
+      friendly_name,
+      uptime_seconds,
+      version
+    )
   end
 
   def apply_event(


### PR DESCRIPTION
This PR adds `uptime_seconds` and `version` to `Host`

- `uptime_seconds` is useful so consumers can have an authoritative knowledge of how long a host has been running, even if the lattice observer has restarted or wasn't running when a host started
- `version` resolves https://github.com/wasmCloud/lattice-observer/issues/27

Note that hosts prior to https://github.com/wasmCloud/wasmcloud-otp/pull/548 will not include this information. In its absence we fall back to `0` seconds and `v0.0.0` for the version

~(Ignore the first commit. I included it to avoid merge conflicts after https://github.com/wasmCloud/lattice-observer/pull/28 is merged. I will rebase once that is merged)~