### PR TITLE
Support storing JSON schemas

### DIFF
--- a/lib/lattice_observer/observed/claims.ex
+++ b/lib/lattice_observer/observed/claims.ex
@@ -12,7 +12,8 @@ defmodule LatticeObserver.Observed.Claims do
     :caps,
     :rev,
     :tags,
-    :version
+    :version,
+    :config_schema
   ]
 
   @type t :: %Claims{
@@ -25,7 +26,8 @@ defmodule LatticeObserver.Observed.Claims do
           rev: binary(),
           # Comma-delimited list
           tags: binary(),
-          version: binary()
+          version: binary(),
+          config_schema: binary() | nil
         }
 
   # Apply a capability provider's claims

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LatticeObserver.MixProject do
   def project do
     [
       app: :lattice_observer,
-      version: "0.4.0",
+      version: "0.4.1",
       elixir: "~> 1.12",
       elixirc_paths: compiler_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
If the `config_schema` field is present on a set of claims, then the lattice observer will store it and make it available in the struct.