### PR TITLE
ignore unimportant events

### DIFF
--- a/lib/lattice_observer/observed/lattice.ex
+++ b/lib/lattice_observer/observed/lattice.ex
@@ -261,6 +261,18 @@ defmodule LatticeObserver.Observed.Lattice do
   def apply_event(
         l = %Lattice{},
         %Cloudevents.Format.V_1_0.Event{
+          datacontenttype: "application/json",
+          source: _source_host,
+          type: "com.wasmcloud.lattice.health_check_status"
+        }
+      ) do
+    # No-op. We don't care about unchanged statuses
+    l
+  end
+
+  def apply_event(
+        l = %Lattice{},
+        %Cloudevents.Format.V_1_0.Event{
           data:
             %{
               "public_key" => pk,
@@ -354,6 +366,18 @@ defmodule LatticeObserver.Observed.Lattice do
   def apply_event(
         l = %Lattice{},
         %Cloudevents.Format.V_1_0.Event{
+          datacontenttype: "application/json",
+          source: _source_host,
+          type: "com.wasmcloud.lattice.actors_stopped"
+        }
+      ) do
+    # No-op. We handle each of the actor_stopped events instead
+    l
+  end
+
+  def apply_event(
+        l = %Lattice{},
+        %Cloudevents.Format.V_1_0.Event{
           data:
             %{
               "public_key" => pk,
@@ -386,6 +410,18 @@ defmodule LatticeObserver.Observed.Lattice do
   def apply_event(
         l = %Lattice{},
         %Cloudevents.Format.V_1_0.Event{
+          datacontenttype: "application/json",
+          source: _source_host,
+          type: "com.wasmcloud.lattice.actors_started"
+        }
+      ) do
+    # No-op. We handle each of the actor_started events instead
+    l
+  end
+
+  def apply_event(
+        l = %Lattice{},
+        %Cloudevents.Format.V_1_0.Event{
           source: _source_host,
           datacontenttype: "application/json",
           time: _stamp,
@@ -393,6 +429,18 @@ defmodule LatticeObserver.Observed.Lattice do
         }
       ) do
     # This does not currently affect state, but shouldn't generate a warning either
+    l
+  end
+
+  def apply_event(
+        l = %Lattice{},
+        %Cloudevents.Format.V_1_0.Event{
+          datacontenttype: "application/json",
+          source: _source_host,
+          type: "com.wasmcloud.lattice.actors_start_failed"
+        }
+      ) do
+    # No-op. We handle each of the actor_start_failed events instead
     l
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LatticeObserver.MixProject do
   def project do
     [
       app: :lattice_observer,
-      version: "0.4.1",
+      version: "0.4.2",
       elixir: "~> 1.12",
       elixirc_paths: compiler_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Feature or Problem
The lattice observer prints warning messages any time it receives an unexpected event. We've added a few events the host can emit, so I've added cases to the lattice observer so it won't emit warnings on expected events anymore

## Release Information
v0.4.2

## Consumer Impact
N/A

## Testing

### Manual Verification
- Started an application which uses the lattice observer
- Ran `wash up` on version 0.18, which starts v0.63.1 of the host
- Started an actor and provider, and waited 30s for the health check event
- Confirmed no warnings were printed by the lattice observer