### PR TITLE
fix(observer)!: observe actor annotations instead of spec ID

### DIFF
--- a/lib/lattice_observer/observed/event_processor.ex
+++ b/lib/lattice_observer/observed/event_processor.ex
@@ -257,13 +257,13 @@ defmodule LatticeObserver.Observed.EventProcessor do
           end)
 
         l =
-          List.foldl(actors_expanded, l, fn public_key, acc ->
+          List.foldl(actors_expanded, l, fn {public_key, annotations}, acc ->
             put_actor_instance(
               acc,
               source_host,
               public_key,
               "n/a",
-              %{},
+              annotations,
               stamp,
               %{}
             )
@@ -294,8 +294,8 @@ defmodule LatticeObserver.Observed.EventProcessor do
           acc,
           source_host,
           x["public_key"],
-          "n/a",
-          x["annotations"],
+          Map.get(x, "instance_id", "n/a"),
+          Map.get(x, "annotations", %{}),
           stamp,
           %{}
         )
@@ -308,8 +308,8 @@ defmodule LatticeObserver.Observed.EventProcessor do
         x["public_key"],
         x["link_name"],
         x["contract_id"],
-        "n/a",
-        x["annotations"],
+        Map.get(x, "instance_id", "n/a"),
+        Map.get(x, "annotations", %{}),
         stamp,
         %{}
       )

--- a/lib/lattice_observer/observed/instance.ex
+++ b/lib/lattice_observer/observed/instance.ex
@@ -1,8 +1,8 @@
 defmodule LatticeObserver.Observed.Instance do
   alias __MODULE__
 
-  @enforce_keys [:id, :host_id, :spec_id]
-  defstruct [:id, :host_id, :spec_id, :version, :revision]
+  @enforce_keys [:id, :host_id, :annotations]
+  defstruct [:id, :host_id, :annotations, :version, :revision]
 
   @typedoc """
   An instance represents an observation of a unit of scalability within the lattice. Instances
@@ -13,7 +13,7 @@ defmodule LatticeObserver.Observed.Instance do
   @type t :: %Instance{
           id: binary(),
           host_id: binary(),
-          spec_id: binary(),
+          annotations: map(),
           version: binary(),
           revision: integer()
         }

--- a/lib/lattice_observer/observed/lattice.ex
+++ b/lib/lattice_observer/observed/lattice.ex
@@ -331,6 +331,45 @@ defmodule LatticeObserver.Observed.Lattice do
   def apply_event(
         l = %Lattice{},
         %Cloudevents.Format.V_1_0.Event{
+          source: _source_host,
+          datacontenttype: "application/json",
+          time: _stamp,
+          type: "com.wasmcloud.lattice.health_check_status"
+        }
+      ) do
+    # This does not currently affect state, but shouldn't generate a warning either
+    l
+  end
+
+  def apply_event(
+        l = %Lattice{},
+        %Cloudevents.Format.V_1_0.Event{
+          source: _source_host,
+          datacontenttype: "application/json",
+          time: _stamp,
+          type: "com.wasmcloud.lattice.actors_started"
+        }
+      ) do
+    # This does not currently affect state, but shouldn't generate a warning either
+    l
+  end
+
+  def apply_event(
+        l = %Lattice{},
+        %Cloudevents.Format.V_1_0.Event{
+          source: _source_host,
+          datacontenttype: "application/json",
+          time: _stamp,
+          type: "com.wasmcloud.lattice.actors_stopped"
+        }
+      ) do
+    # This does not currently affect state, but shouldn't generate a warning either
+    l
+  end
+
+  def apply_event(
+        l = %Lattice{},
+        %Cloudevents.Format.V_1_0.Event{
           data:
             %{
               "link_name" => link_name,

--- a/test/observed/actors_test.exs
+++ b/test/observed/actors_test.exs
@@ -24,7 +24,7 @@ defmodule LatticeObserverTest.Observed.ActorsTest do
                          host_id: "Nxxx",
                          id: "abc123",
                          revision: 0,
-                         spec_id: "testapp",
+                         annotations: %{"wasmcloud.dev/appspec" => "testapp"},
                          version: "1.0"
                        }
                      ],

--- a/test/observed/decay_test.exs
+++ b/test/observed/decay_test.exs
@@ -98,7 +98,7 @@ defmodule LatticeObserverTest.Observed.DecayTest do
                      host_id: "Nxxx",
                      id: "abc123",
                      revision: 0,
-                     spec_id: "none",
+                     annotations: %{"wasmcloud.dev/appspec" => "none"},
                      version: "1.0"
                    }
                  ],
@@ -137,7 +137,7 @@ defmodule LatticeObserverTest.Observed.DecayTest do
                      host_id: "Nxxx",
                      id: "abc123",
                      revision: 0,
-                     spec_id: "none",
+                     annotations: %{"wasmcloud.dev/appspec" => "none"},
                      version: "1.0"
                    }
                  ],

--- a/test/observed/hosts_test.exs
+++ b/test/observed/hosts_test.exs
@@ -209,7 +209,7 @@ defmodule LatticeObserverTest.Observed.HostsTest do
                      host_id: "Nxxx",
                      id: "iid1",
                      revision: 0,
-                     spec_id: "",
+                     annotations: %{},
                      version: ""
                    }
                  ],
@@ -228,7 +228,7 @@ defmodule LatticeObserverTest.Observed.HostsTest do
                      host_id: "Nxxx",
                      id: "iid3",
                      revision: 0,
-                     spec_id: "",
+                     annotations: %{},
                      version: ""
                    }
                  ],
@@ -305,7 +305,7 @@ defmodule LatticeObserverTest.Observed.HostsTest do
                      host_id: "Nxxx",
                      id: "n/a",
                      revision: 0,
-                     spec_id: "",
+                     annotations: %{},
                      version: ""
                    }
                  ],
@@ -324,7 +324,7 @@ defmodule LatticeObserverTest.Observed.HostsTest do
                      host_id: "Nxxx",
                      id: "n/a",
                      revision: 0,
-                     spec_id: "",
+                     annotations: %{},
                      version: ""
                    }
                  ],

--- a/test/observed/providers_test.exs
+++ b/test/observed/providers_test.exs
@@ -3,8 +3,8 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
   alias LatticeObserver.Observed.{Lattice, Instance, Provider, EventProcessor}
   alias TestSupport.CloudEvents
 
-  @test_spec "testapp"
-  @test_spec_2 "othertestapp"
+  @test_spec %{"wasmcloud.dev/appspec" => "testapp"}
+  @test_spec_2 %{"wasmcloud.dev/appspec" => "othertestapp"}
   @test_host "Nxxx"
   @test_host2 "Nxxy"
   @test_contract "wasmcloud:test"
@@ -51,7 +51,7 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
                   host_id: "Nxxx",
                   id: "n/a",
                   revision: 2,
-                  spec_id: "testapp",
+                  annotations: %{"wasmcloud.dev/appspec" => "testapp"},
                   version: "1.0"
                 }
               ],
@@ -152,7 +152,7 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
                          host_id: "Nxxx",
                          id: "n/a",
                          revision: 2,
-                         spec_id: "testapp",
+                         annotations: %{"wasmcloud.dev/appspec" => "testapp"},
                          version: "1.0"
                        }
                      ],
@@ -169,7 +169,7 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
                          host_id: "Nxxx",
                          id: "n/a",
                          revision: 2,
-                         spec_id: "testapp",
+                         annotations: %{"wasmcloud.dev/appspec" => "testapp"},
                          version: "1.0"
                        }
                      ],
@@ -224,14 +224,14 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
                        %Instance{
                          host_id: "Nxxy",
                          id: "n/a",
-                         spec_id: "othertestapp",
+                         annotations: %{"wasmcloud.dev/appspec" => "othertestapp"},
                          revision: 2,
                          version: "1.0"
                        },
                        %Instance{
                          host_id: "Nxxx",
                          id: "n/a",
-                         spec_id: "testapp",
+                         annotations: %{"wasmcloud.dev/appspec" => "testapp"},
                          revision: 2,
                          version: "1.0"
                        }
@@ -246,7 +246,7 @@ defmodule LatticeObserverTest.Observed.ProvidersTest do
                          host_id: "Nxxx",
                          id: "n/a",
                          revision: 2,
-                         spec_id: "testapp",
+                         annotations: %{"wasmcloud.dev/appspec" => "testapp"},
                          version: "1.0"
                        }
                      ],


### PR DESCRIPTION
## Feature or Problem
This PR updates the lattice observer to keep track of instance annotations rather than just the appspec ID.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
v0.5.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
Modified tests to test against an annotations map rather than a single spec ID

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
