### PR TITLE
fix: use annotations on provider start

### DIFF
--- a/lib/lattice_observer/observed/lattice.ex
+++ b/lib/lattice_observer/observed/lattice.ex
@@ -287,7 +287,6 @@ defmodule LatticeObserver.Observed.Lattice do
         }
       ) do
     annotations = Map.get(d, "annotations", %{})
-    spec = Map.get(annotations, @annotation_app_spec, "")
     claims = Map.get(d, "claims", %{})
 
     l =
@@ -309,7 +308,7 @@ defmodule LatticeObserver.Observed.Lattice do
       link_name,
       contract_id,
       instance_id,
-      spec,
+      annotations,
       stamp,
       claims
     )

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LatticeObserver.MixProject do
   def project do
     [
       app: :lattice_observer,
-      version: "0.4.2",
+      version: "0.4.3",
       elixir: "~> 1.12",
       elixirc_paths: compiler_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/support/cloud_events.ex
+++ b/test/support/cloud_events.ex
@@ -74,13 +74,13 @@ defmodule TestSupport.CloudEvents do
     |> Cloudevents.from_map!()
   end
 
-  def provider_started(pk, contract_id, link_name, instance_id, spec, host) do
+  def provider_started(pk, contract_id, link_name, instance_id, annotations, host) do
     %{
       "public_key" => pk,
       "instance_id" => instance_id,
       "link_name" => link_name,
       "contract_id" => contract_id,
-      "annotations" => %{@appspec => spec},
+      "annotations" => annotations,
       "claims" => %{
         "name" => "test provider",
         "version" => "1.0",


### PR DESCRIPTION
## Feature or Problem
This PR fixes an issue where we were still using a spec ID instead of annotations on provider started.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
v0.4.3

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
