### PR TITLE
feat(*): support actor_scaled event

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-11]
+        os: [ubuntu-22.04, windows-2022, macos-12]
         elixir: [1.13.4]
         otp: [25]
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LatticeObserver.MixProject do
   def project do
     [
       app: :lattice_observer,
-      version: "0.4.3",
+      version: "0.5.0",
       elixir: "~> 1.12",
       elixirc_paths: compiler_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/observed/actors_test.exs
+++ b/test/observed/actors_test.exs
@@ -5,6 +5,7 @@ defmodule LatticeObserverTest.Observed.ActorsTest do
 
   @test_spec "testapp"
   @test_host "Nxxx"
+  @test_host_2 "Nyyy"
 
   describe "Observed Lattice Monitors Actor Events" do
     test "Adds and Removes actors" do
@@ -69,6 +70,93 @@ defmodule LatticeObserverTest.Observed.ActorsTest do
                    }
                  }
              }
+    end
+
+    test "Scaled event modifies actor list" do
+      start =
+        CloudEvents.actor_scaled(
+          "Myyy",
+          @test_spec,
+          @test_host_2,
+          "mything.cloud.io/actor:latest",
+          1
+        )
+
+      l = Lattice.new()
+      l = Lattice.apply_event(l, start)
+
+      assert l == %Lattice{
+               Lattice.new()
+               | actors: %{
+                   "Myyy" => %Actor{
+                     call_alias: "",
+                     capabilities: ["test", "test2"],
+                     id: "Myyy",
+                     instances: [
+                       %Instance{
+                         host_id: "Nyyy",
+                         id: "N/A",
+                         revision: 0,
+                         annotations: %{"wasmcloud.dev/appspec" => "testapp"},
+                         version: "1.0"
+                       }
+                     ],
+                     issuer: "ATESTxxx",
+                     name: "Test Actor",
+                     tags: ""
+                   }
+                 },
+                 claims: %{
+                   "Myyy" => %LatticeObserver.Observed.Claims{
+                     call_alias: "",
+                     caps: "test,test2",
+                     iss: "ATESTxxx",
+                     name: "Test Actor",
+                     rev: 0,
+                     sub: "Myyy",
+                     tags: "",
+                     version: "1.0"
+                   }
+                 },
+                 instance_tracking: %{}
+             }
+
+      scale_up =
+        CloudEvents.actor_scaled(
+          "Myyy",
+          @test_spec,
+          @test_host_2,
+          "mything.cloud.io/actor:latest",
+          500
+        )
+
+      l = Lattice.apply_event(l, scale_up)
+      assert l.actors["Myyy"].instances |> length() == 500
+
+      scale_down =
+        CloudEvents.actor_scaled(
+          "Myyy",
+          @test_spec,
+          @test_host_2,
+          "mything.cloud.io/actor:latest",
+          123
+        )
+
+      l = Lattice.apply_event(l, scale_down)
+      assert l.actors["Myyy"].instances |> length() == 123
+
+      scale_to_zero =
+        CloudEvents.actor_scaled(
+          "Myyy",
+          @test_spec,
+          @test_host_2,
+          "mything.cloud.io/actor:latest",
+          0
+        )
+
+      l = Lattice.apply_event(l, scale_to_zero)
+      actor = Map.get(l.actors, "Myyy", nil)
+      assert is_nil(actor)
     end
   end
 end

--- a/test/support/cloud_events.ex
+++ b/test/support/cloud_events.ex
@@ -42,6 +42,25 @@ defmodule TestSupport.CloudEvents do
     |> LatticeObserver.CloudEvent.new("actor_started", host)
   end
 
+  def actor_scaled(pk, spec, host, image_ref, scale, name \\ "Test Actor") do
+    %{
+      "public_key" => pk,
+      "annotations" => %{@appspec => spec},
+      "claims" => %{
+        "name" => name,
+        "caps" => ["test", "test2"],
+        "version" => "1.0",
+        "revision" => 0,
+        "tags" => "",
+        "issuer" => "ATESTxxx"
+      },
+      "host_id" => host,
+      "image_ref" => image_ref,
+      "max_instances" => scale
+    }
+    |> LatticeObserver.CloudEvent.new("actor_scaled", host)
+  end
+
   def actor_stopped(pk, instance_id, spec, host) do
     %{"public_key" => pk, "instance_id" => instance_id, "annotations" => %{@appspec => spec}}
     |> LatticeObserver.CloudEvent.new("actor_stopped", host)


### PR DESCRIPTION
- feat(*): support actor_scaled event
- chore: bump version to 0.5.0

## Feature or Problem
This PR adds support for the `actor_scaled` event which will allow the lattice observer to modify the instances state with the single event instead of handling the individual `actor_started`/`actor_stopped` events. I'm leapfrogging the plural events here as we didn't have support for them and after wasmCloud v0.82 is released we won't need them anyways.

There will be another PR shortly supporting the new heartbeat format which will also make it into 0.5.0.

## Related Issues
The actor scaled event includes the image ref, which could enable #16 

## Release Information
0.5.0

## Consumer Impact
No consumer impact as this event isn't even released yet.

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
Added a unit test to validate functionality. All instance IDs are just supplanted as `N/A` as they don't matter.

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
